### PR TITLE
COMP: Use ExtractCenterline module in custom apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 #-----------------------------------------------------------------------------
 add_subdirectory(VesselnessFiltering)
 add_subdirectory(LevelSetSegmentation)
-if(${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR} VERSION_GREATER_EQUAL 4.11)
+if(${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR} VERSION_GREATER_EQUAL 4.11 OR ${Slicer_VERSION_MAJOR} EQUAL 0)
   # New-generation centerline computation - only available for recent Slicer versions
   add_subdirectory(ExtractCenterline)
 else()


### PR DESCRIPTION
In the custom app superbuild the variables Slicer_VERSION_MAJOR and Slicer_VERSION_MINOR are both 0 (although the Slicer_VERSION_FULL variable is correct). To fix this problem, we assume that if the version is 0 then 4.13 or later is used.