### PR TITLE
Add RAS point coordinates to centerline model table.

### DIFF
--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -205,6 +205,9 @@ class CenterlineMetricsLogic(ScriptedLoadableModuleLogic):
     # Create arrays of data
     distanceArray = self.getArrayFromTable(outputTable, DISTANCE_ARRAY_NAME)
     diameterArray = self.getArrayFromTable(outputTable, DIAMETER_ARRAY_NAME)
+    rArray = self.getArrayFromTable(outputTable, R_ARRAY_NAME)
+    aArray = self.getArrayFromTable(outputTable, A_ARRAY_NAME)
+    sArray = self.getArrayFromTable(outputTable, S_ARRAY_NAME)
 
     # From VMTK README.md
     points = slicer.util.arrayFromModelPoints(inputModel)
@@ -219,6 +222,9 @@ class CenterlineMetricsLogic(ScriptedLoadableModuleLogic):
         else:
             distanceArray.SetValue(i, cumArray.GetValue(i))
         diameterArray.SetValue(i, radius * 2)
+        rArray.SetValue(i, points[i][0])
+        aArray.SetValue(i, points[i][1])
+        sArray.SetValue(i, points[i][2])
     distanceArray.Modified()
     diameterArray.Modified()
     outputTable.GetTable().Modified()
@@ -285,3 +291,7 @@ class CenterlineMetricsTest(ScriptedLoadableModuleTest):
 
 DISTANCE_ARRAY_NAME = "Distance"
 DIAMETER_ARRAY_NAME = "Diameter"
+R_ARRAY_NAME = "R"
+A_ARRAY_NAME = "A"
+S_ARRAY_NAME = "S"
+

--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -251,7 +251,7 @@ class CenterlineMetricsLogic(ScriptedLoadableModuleLogic):
         apArray = self.getArrayFromTable(outputTable, self.AP_ARRAY_NAME)
         siArray = self.getArrayFromTable(outputTable, self.SI_ARRAY_NAME)
     else:
-        tripletArray = siArray = self.getArrayFromTable(outputTable, self.TRIPLET_ARRAY_NAME, True)
+        tripletArray = self.getArrayFromTable(outputTable, self.TRIPLET_ARRAY_NAME, True)
 
     # From VMTK README.md
     points = slicer.util.arrayFromModelPoints(inputModel)

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>424</width>
-    <height>378</height>
+    <width>467</width>
+    <height>526</height>
    </rect>
   </property>
   <layout class="QFormLayout" name="formLayout">
@@ -110,7 +110,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QPushButton" name="applyButton">
      <property name="enabled">
       <bool>false</bool>
@@ -123,7 +123,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -137,14 +137,20 @@
     </spacer>
    </item>
    <item row="4" column="0" colspan="2">
-    <widget class="qMRMLCollapsibleButton" name="moreCollapsibleButton">
+    <widget class="qMRMLCollapsibleButton" name="distanceCollapsibleButton">
+     <property name="toolTip">
+      <string>How is distance calculated</string>
+     </property>
+     <property name="locale">
+      <locale language="English" country="UnitedStates"/>
+     </property>
      <property name="text">
-      <string>More</string>
+      <string>Distance mode</string>
      </property>
      <property name="checked">
       <bool>false</bool>
      </property>
-     <layout class="QFormLayout" name="moreFormLayout">
+     <layout class="QFormLayout" name="distanceFormLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="distanceModeLabel">
         <property name="text">
@@ -224,6 +230,60 @@
            </property>
            <property name="text">
             <string>S</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="qMRMLCollapsibleButton" name="tableCoordinatesCollapsibleButton">
+     <property name="toolTip">
+      <string>How to show point coordinates in the table</string>
+     </property>
+     <property name="locale">
+      <locale language="English" country="UnitedStates"/>
+     </property>
+     <property name="text">
+      <string>Table coordinates</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="tableCoordinatesFormLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="tableCoordinatesTypeLabel">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QGroupBox" name="groupBox">
+        <property name="toolTip">
+         <string>Choose a coordinate system</string>
+        </property>
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QHBoxLayout" name="tableCoordinatesTypeLayout">
+         <item>
+          <widget class="QRadioButton" name="radioLPS">
+           <property name="text">
+            <string>LPS</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radioRAS">
+           <property name="text">
+            <string>RAS</string>
            </property>
           </widget>
          </item>

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -251,7 +251,7 @@
       <string>Table coordinates</string>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <layout class="QFormLayout" name="tableCoordinatesFormLayout">
       <item row="0" column="0">
@@ -288,6 +288,16 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="distinctColumnsCheckBox">
+        <property name="toolTip">
+         <string>Either one column with an array of values, or a distinct column for each value of the triplet.</string>
+        </property>
+        <property name="text">
+         <string>In distinct columns</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -251,7 +251,7 @@
       <string>Table coordinates</string>
      </property>
      <property name="checked">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <layout class="QFormLayout" name="tableCoordinatesFormLayout">
       <item row="0" column="0">


### PR DESCRIPTION
In addition to distance and diameter columns, three more columns R, A, S
are added, corresponding to the coordinates of each point of the
centerline model.

Following https://discourse.slicer.org/t/veselness-filter/17739

The user requesting this has not specified its usefullness. It seems harmless though.