### PR TITLE
COMP: Update VMTK to fix Visual Studio build

### DIFF
--- a/SuperBuild/External_VMTK.cmake
+++ b/SuperBuild/External_VMTK.cmake
@@ -50,7 +50,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "bdddd70cc2ed40a10ba85bff1279d910db31fc1e"
+    "671b54d7b3b243d3d2ce662ffa7f678f53ee18a1"
     QUIET
     )
 


### PR DESCRIPTION
This commit updates VMTK to fix a regression introduced in be5ac3a (COMP: Fix
build against VTK8 specifying VMTK_USE_VTK9 build option)

List of changes:

```
$ git shortlog bdddd70..671b54d --no-merges
Jean-Christophe Fillion-Robin (2):
      COMP: Update pragma use in vtkvmtkSimplifyVoronoiDiagram to Fix Visual Studio build
      COMP: Fix Visual Studio build of vtkvmtkRBFInterpolation when VTK_LEGACY_REMOVE is ON
```