### PR TITLE
Merge 'Cross-section analysis' module with 'Centerline metrics'

### DIFF
--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -415,30 +415,6 @@ class CenterlineMetricsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     self.updateSliceViewOrientationMetrics()
     
   def updateSliceViewOrientationMetrics(self):
-    """
-    Please remove comment if commit in trunk.
-    Using hexadecimal for degree character.
-    For obscure reasons, using the degree character triggers :
-    
-    Python 3.6.7 (default, Aug 22 2021, 12:05:08) 
-[GCC Clang 12.0.1] on linux2
->>> 
-Traceback (most recent call last):
-  File "<string>", line 1, in <module>
-  File "/home/user/programs/Slicer/lib/Python/lib/python3.6/imp.py", line 170, in load_source
-    module = _exec(spec, sys.modules[name])
-  File "<frozen importlib._bootstrap>", line 618, in _exec
-  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
-  File "<frozen importlib._bootstrap_external>", line 781, in get_code
-  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
-  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
-  File "/home/user/programs/Slicer/bin/../lib/Slicer-4.13/qt-scripted-modules/CenterlineMetrics.py", line 389
-SyntaxError: (unicode error) 'utf-8' codec can't decode byte 0xb0 in position 0: invalid start byte
-Loading Slicer RC file [/home/user/.slicerrc.py]
-
-    This character is used seamlessly in CrossSectionAnalysis.py though.
-    
-    """
     if self.ui.sliceViewSelector.currentNode():
         orient = self.logic.getSliceOrientation(self.ui.sliceViewSelector.currentNode())
         orientation = "R " + str(round(orient[0], 1)) + chr(0xb0) + ","

--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -855,7 +855,7 @@ class CenterlineMetricsLogic(ScriptedLoadableModuleLogic):
 
   def getPositionMaximumInscribedSphereRadius(self, pointIndex):
     if not self.isCenterlineRadiusAvailable:
-      raise ValueError("Maximim inscribed sphere radius is not available")
+      raise ValueError("Maximum inscribed sphere radius is not available")
     position = np.zeros(3)
     if self.inputCenterlineNode.IsTypeOf("vtkMRMLModelNode"):
       positionLocal = slicer.util.arrayFromModelPoints(self.inputCenterlineNode)[pointIndex]

--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -322,17 +322,15 @@ class CenterlineMetricsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
   
   def onJumpCentredInSliceNodeCheckBox(self):
     self.logic.jumpCentredInSliceNode = self.ui.jumpCentredInSliceNodeCheckBox.checked
+    if self.ui.sliceViewSelector.currentNode():
+        self.setCurrentPointIndex(self.ui.moveToPointSliderWidget.value)
+        self.updateSliceViewOrientationMetrics()
   
   def onOrthogonalReformatInSliceNodeCheckBox (self):
     self.logic.orthogonalReformatInSliceNode = self.ui.orthogonalReformatInSliceNodeCheckBox.checked
-    inputSliceNode = self.ui.sliceViewSelector.currentNode()
-    if self.ui.orthogonalReformatInSliceNodeCheckBox.checked:
-        if inputSliceNode and self.ui.inputCenterlineSelector.currentNode():
-            self.logic.updateSliceView(inputSliceNode, self.ui.moveToPointSliderWidget.value)
-    else:
-        if inputSliceNode:
-            inputSliceNode.SetOrientationToDefault()
-    self.updateSliceViewOrientationMetrics()
+    if self.ui.sliceViewSelector.currentNode():
+        self.setCurrentPointIndex(self.ui.moveToPointSliderWidget.value)
+        self.updateSliceViewOrientationMetrics()
   
   def onSelectSliceNode(self, sliceNode):
     self.logic.selectSliceNode(sliceNode)
@@ -863,8 +861,7 @@ class CenterlineMetricsLogic(ScriptedLoadableModuleLogic):
     return position
 
   def updateSliceView(self, sliceNode, value):
-    """Move the selected slice view to a point of the centerline, optionally centering on the point.
-    The slice view orientation, reformat or not, is not changed.
+    """Move the selected slice view to a point of the centerline, optionally centering on the point, and with optional orthogonal reformat.
     """
     position = self.getCurvePointPositionAtIndex(value)
     
@@ -878,6 +875,8 @@ class CenterlineMetricsLogic(ScriptedLoadableModuleLogic):
         direction = self.getCurvePointPositionAtIndex(value + 1) - position
         reformatLogic.SetSliceOrigin(sliceNode, position[0], position[1], position[2])
         reformatLogic.SetSliceNormal(sliceNode, direction[0], direction[1], direction[2])
+    else:
+        sliceNode.SetOrientationToDefault()
 
   def getExtremeDiameterPoint(self, boolMaximum):
     """Convenience function to get the point of minimum or maximum diameter.

--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -94,7 +94,7 @@ class CenterlineMetricsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
 
     # connections
     self.ui.applyButton.connect('clicked(bool)', self.onApplyButton)
-    self.ui.inputModelSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onSelectNode)
+    self.ui.inputCenterlineSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onSelectNode)
     self.ui.outputPlotSeriesSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onSelectNode)
     self.ui.outputTableSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onSelectNode)
     self.ui.radioLPS.connect("clicked()", self.onRadioLPS)
@@ -123,7 +123,7 @@ class CenterlineMetricsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     self.removeObservers()
   
   def onSelectNode(self):
-    self.logic.setInputCenterlineNode(self.ui.inputModelSelector.currentNode())
+    self.logic.setInputCenterlineNode(self.ui.inputCenterlineSelector.currentNode())
     self.ui.applyButton.enabled = self.logic.isInputCenterlineValid()
     self.logic.setOutputTableNode(self.ui.outputTableSelector.currentNode())
     self.logic.setOutputPlotSeriesNode(self.ui.outputPlotSeriesSelector.currentNode())
@@ -186,7 +186,7 @@ class CenterlineMetricsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     self.logic.orthogonalReformatInSliceNode = self.ui.orthogonalReformatInSliceNodeCheckBox.checked
     inputSliceNode = self.ui.sliceViewSelector.currentNode()
     if self.ui.orthogonalReformatInSliceNodeCheckBox.checked:
-        if inputSliceNode and self.ui.inputModelSelector.currentNode():
+        if inputSliceNode and self.ui.inputCenterlineSelector.currentNode():
             self.logic.updateSliceView(inputSliceNode, self.ui.moveToPointSliderWidget.value)
     else:
         if inputSliceNode:

--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -91,7 +91,6 @@ class CenterlineMetricsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     self.previousLayoutId = slicer.app.layoutManager().layout
 
     self.ui.jumpCentredInSliceNodeCheckBox.setIcon(qt.QIcon(':/Icons/ViewCenter.png'))
-    # Until we know where to browse available icons, to use another one. ViewCenter.png has not been found in ./Slicer-*/*. Probably in a resource bundle somewhere.
     self.ui.orthogonalReformatInSliceNodeCheckBox.setIcon(qt.QIcon(':/Icons/ViewCenter.png'))
     
     # These connections ensure that we update parameter node when scene is closed

--- a/CenterlineMetrics/CenterlineMetrics.py
+++ b/CenterlineMetrics/CenterlineMetrics.py
@@ -346,8 +346,9 @@ class CenterlineMetricsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     self.updateSliceViewOrientationMetrics()
     if sliceNode is None:
         self.ui.orientationValueLabel.setText("")
+    else:
+        sliceNode.SetAttribute("currentTilt", "0.0")
     self.ui.torsionSliderWidget.value = 0.0
-    sliceNode.SetAttribute("currentTilt", "0.0")
     
   def updateUIWithMetrics(self, value):
     pointIndex = int(value)

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -630,7 +630,7 @@ Caution: values at bifurcations may not have clinical meaning.</string>
       <item row="2" column="1">
        <widget class="qMRMLSpinBox" name="relativeOriginSpinBox">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>425</width>
-    <height>421</height>
+    <height>476</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -316,10 +316,10 @@ The input centerline is expected to be inside the lumen surface.</string>
       <string>Browse cross-sections</string>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="collapsed">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="horizontalSpacing">
@@ -383,6 +383,19 @@ The input centerline is expected to be inside the lumen surface.</string>
           </property>
           <property name="text">
            <string>centered</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="orthogonalReformatInSliceNodeCheckBox">
+          <property name="toolTip">
+           <string>Orient the slice view orthogonal to the centerline</string>
+          </property>
+          <property name="text">
+           <string>reformat</string>
           </property>
           <property name="checkable">
            <bool>true</bool>

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>536</width>
-    <height>800</height>
+    <height>842</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -643,14 +643,14 @@ Caution: values at bifurcations may not have clinical meaning.</string>
       <item row="9" column="0">
        <widget class="QLabel" name="torsionLabel">
         <property name="text">
-         <string>Torsion:</string>
+         <string>Rotate:</string>
         </property>
        </widget>
       </item>
       <item row="9" column="1">
        <widget class="ctkSliderWidget" name="torsionSliderWidget">
         <property name="toolTip">
-         <string>Rotate slice view</string>
+         <string>Rotate slice view around its Z-axis to restore anatomic orientation</string>
         </property>
         <property name="statusTip">
          <string/>

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -600,6 +600,26 @@ Caution: values at bifurcations may not have clinical meaning.</string>
         </property>
        </widget>
       </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="orientationLabel">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Orientation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLabel" name="orientationValueLabel">
+        <property name="toolTip">
+         <string>Angles are in Slicer's coordinate system</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>425</width>
-    <height>476</height>
+    <width>536</width>
+    <height>758</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -430,7 +430,7 @@ The input centerline is expected to be inside the lumen surface.</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="distanceLabel">
         <property name="locale">
          <locale language="English" country="UnitedStates"/>
@@ -440,7 +440,7 @@ The input centerline is expected to be inside the lumen surface.</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QLabel" name="distanceValueLabel">
         <property name="toolTip">
          <string>Cumulative distance from start of centerline</string>
@@ -453,7 +453,7 @@ The input centerline is expected to be inside the lumen surface.</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="coordinatesLabel">
         <property name="locale">
          <locale language="English" country="UnitedStates"/>
@@ -463,7 +463,7 @@ The input centerline is expected to be inside the lumen surface.</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QLabel" name="coordinatesValueLabel">
         <property name="toolTip">
          <string>RAS coordinate of selected point</string>
@@ -482,7 +482,7 @@ The input centerline is expected to be inside the lumen surface.</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="diameterLabel">
         <property name="locale">
          <locale language="English" country="UnitedStates"/>
@@ -492,7 +492,7 @@ The input centerline is expected to be inside the lumen surface.</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLabel" name="diameterValueLabel">
@@ -542,14 +542,14 @@ The input centerline is expected to be inside the lumen surface.</string>
         </item>
        </layout>
       </item>
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="surfaceAreaLabel">
         <property name="text">
          <string>Cross-sectional area:</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="surfaceAreaValueLabel">
@@ -579,14 +579,14 @@ The input centerline is expected to be inside the lumen surface.</string>
         </item>
        </layout>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="derivedDiameterLabel">
         <property name="text">
          <string>Diameter (CE):</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="QLabel" name="derivedDiameterValueLabel">
         <property name="toolTip">
          <string>Circular equivalent (CE) diameter: that of a circle having the  surface area of the cross-section.
@@ -600,7 +600,7 @@ Caution: values at bifurcations may not have clinical meaning.</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="orientationLabel">
         <property name="toolTip">
          <string/>
@@ -610,13 +610,33 @@ Caution: values at bifurcations may not have clinical meaning.</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="8" column="1">
        <widget class="QLabel" name="orientationValueLabel">
         <property name="toolTip">
          <string>Angles are in Slicer's coordinate system</string>
         </property>
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Relative origin:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="qMRMLSpinBox" name="relativeOriginSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Distance will be calculated relative to this point</string>
         </property>
        </widget>
       </item>
@@ -652,6 +672,11 @@ Caution: values at bifurcations may not have clinical meaning.</string>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>ctkDoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header>ctkDoubleSpinBox.h</header>
+  </customwidget>
+  <customwidget>
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
@@ -660,6 +685,11 @@ Caution: values at bifurcations may not have clinical meaning.</string>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSpinBox</class>
+   <extends>ctkDoubleSpinBox</extends>
+   <header>qMRMLSpinBox.h</header>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -34,7 +34,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="inputModelSelector">
+       <widget class="qMRMLNodeComboBox" name="inputCenterlineSelector">
         <property name="toolTip">
          <string>Pick the input VMTK centerline.</string>
         </property>
@@ -658,7 +658,7 @@ Caution: values at bifurcations may not have clinical meaning.</string>
   <connection>
    <sender>CenterlineMetrics</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>inputModelSelector</receiver>
+   <receiver>inputCenterlineSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
+++ b/CenterlineMetrics/Resources/UI/CenterlineMetrics.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>536</width>
-    <height>758</height>
+    <height>800</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -637,6 +637,35 @@ Caution: values at bifurcations may not have clinical meaning.</string>
         </property>
         <property name="toolTip">
          <string>Distance will be calculated relative to this point</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="torsionLabel">
+        <property name="text">
+         <string>Torsion:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="ctkSliderWidget" name="torsionSliderWidget">
+        <property name="toolTip">
+         <string>Rotate slice view</string>
+        </property>
+        <property name="statusTip">
+         <string/>
+        </property>
+        <property name="locale">
+         <locale language="English" country="UnitedStates"/>
+        </property>
+        <property name="decimals">
+         <number>0</number>
+        </property>
+        <property name="minimum">
+         <double>-180.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>180.000000000000000</double>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Hi @lassoan,

Following #36

'Cross-section analysis' core functionalities are hereby added to 'Centerline metrics'.

Namely :

 - orthogonal reslicing to centerline points
 - report slice view orientation in Slicer's coordinate system
 - distance of point from a relative origin.
 
Please consider this patch for merge in 'Centerline metrics'.

Regards.