### PR TITLE
Allow to mirror slice views along X and Y axes.

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -25,7 +25,7 @@ class CrossSectionAnalysis(ScriptedLoadableModule):
     self.parent.contributors = ["SET (Surgeon) (Hobbyist developer)", "Andras Lasso (PerkLab)"]
     self.parent.helpText = """
 This module describes cross-sections along a VMTK centerline model, a VMTK centerline markups curve or an arbitrary markups curve. Documentation is available
-    <a href="https://github.com/vmtk/SlicerExtension-VMTK/tree/master/CrossSectionAnalysis">here</a>.
+    <a href="https://github.com/vmtk/SlicerExtension-VMTK/">here</a>.
 """
     self.parent.acknowledgementText = """
 This file was originally developed by SET. Many thanks to Andras Lasso for sanitizing the code and UI, and for guidance throughout.

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -172,11 +172,11 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     """
     Called just after the scene is closed.
     """
+    # Clean up logic variables first. Avoids some Python console errors.
+    self.logic.initMemberVariables()
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
     if self.parent.isEntered:
       self.initializeParameterNode()
-    # Clean up logic variables too.
-    self.logic.initMemberVariables()
 
   def initializeParameterNode(self):
     """

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -1182,7 +1182,16 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
       # Get curve point radius by interpolating control point measurements
       # Need to compute manually until this method becomes available:
       #  radius = self.inputCenterlineNode.GetMeasurement('Radius').GetCurvePointValue(pointIndex)
-      controlPointFloatIndex = self.inputCenterlineNode.GetCurveWorld().GetPointData().GetArray('PedigreeIDs').GetValue(pointIndex)
+      if pointIndex < (self.getNumberOfPoints() - 1):
+        controlPointFloatIndex = self.inputCenterlineNode.GetCurveWorld().GetPointData().GetArray('PedigreeIDs').GetValue(pointIndex)
+      else:
+        """
+        Don't go beyond the last point with controlPointIndexB
+        Else,
+            radiusB = controlPointRadiusValues.GetValue(controlPointIndexB)
+        will fail.
+        """
+        controlPointFloatIndex = self.inputCenterlineNode.GetCurveWorld().GetPointData().GetArray('PedigreeIDs').GetValue(pointIndex - 1)
       controlPointIndexA = int(controlPointFloatIndex)
       controlPointIndexB = controlPointIndexA + 1
       controlPointRadiusValues = self.inputCenterlineNode.GetMeasurement('Radius').GetControlPointValues()

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -125,7 +125,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     # connections
     self.ui.applyButton.connect('clicked(bool)', self.onApplyButton)
 
-    self.ui.inputCenterlineSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
+    self.ui.inputCenterlineSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.logic.setInputCenterlineNode)
     self.ui.outputPlotSeriesSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
     self.ui.outputTableSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
 

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -266,6 +266,12 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.ui.showCrossSectionButton.setChecked(self.logic.showCrossSection)
 
     itemIndex = self.ui.outputPlotSeriesTypeComboBox.findData(self._parameterNode.GetParameter("OutputPlotSeriesType"))
+    """
+    This value is never rightly restored.
+    Prefer a default value rather than unknown.
+    """
+    if itemIndex < 0:
+        itemIndex = 0;
     self.ui.outputPlotSeriesTypeComboBox.setCurrentIndex(itemIndex)
 
     # Update button states

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>558</width>
-    <height>818</height>
+    <width>676</width>
+    <height>910</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -15,6 +15,9 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
+  </property>
+  <property name="toolTip">
+   <string/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -528,7 +531,7 @@ The input centerline is expected to be inside the lumen surface.</string>
       <item row="3" column="1">
        <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_2">
         <property name="title">
-         <string>Spin</string>
+         <string>Spin / Flip</string>
         </property>
         <property name="collapsed">
          <bool>true</bool>
@@ -584,6 +587,13 @@ The input centerline is expected to be inside the lumen surface.</string>
            </property>
           </widget>
          </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Long.:</string>
+           </property>
+          </widget>
+         </item>
          <item row="1" column="1">
           <widget class="ctkSliderWidget" name="longitudinalSpinSliderWidget">
            <property name="enabled">
@@ -612,12 +622,40 @@ The input centerline is expected to be inside the lumen surface.</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
+         <item row="2" column="0">
+          <widget class="QLabel" name="flipLabel">
            <property name="text">
-            <string>Long.:</string>
+            <string>Flip:</string>
            </property>
           </widget>
+         </item>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="mirrorHorizontalLayout">
+           <item>
+            <widget class="QCheckBox" name="axialSliceHorizontalFlipCheckBox">
+             <property name="toolTip">
+              <string>Flip the slice view horizontally.
+
+Concerns orthogonal reformat in axial navigation.</string>
+             </property>
+             <property name="text">
+              <string>Horizontal</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="axialSliceVerticalFlipCheckBox">
+             <property name="toolTip">
+              <string>Flip the slice view vertically.
+
+Concerns orthogonal reformat in axial navigation.</string>
+             </property>
+             <property name="text">
+              <string>Vertical</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
Hi @lassoan ,

Please consider this patch in branch MirrorXY in my fork.

I noticed that reslicing with SetSliceToRASByNTP almost always inverts left/right and/or anterior/posterior orientation. This is disturbing in orthogonal reslicing with axial navigation, which is the most usual analysis as most centerlines are nearly vertical.

This patch does not modify existing functionalities. It only adds two options.

Thank you.
