### PR TITLE
Reduce UI simulation

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -25,7 +25,7 @@ class CrossSectionAnalysis(ScriptedLoadableModule):
     self.parent.contributors = ["SET (Surgeon) (Hobbyist developer)", "Andras Lasso (PerkLab)"]
     self.parent.helpText = """
 This module describes cross-sections along a VMTK centerline model, a VMTK centerline markups curve or an arbitrary markups curve. Documentation is available
-    <a href="https://github.com/vmtk/SlicerExtension-VMTK/tree/master/CrossSectionAnalysis">here</a>.
+    <a href="https://github.com/vmtk/SlicerExtension-VMTK/">here</a>.
 """
     self.parent.acknowledgementText = """
 This file was originally developed by SET. Many thanks to Andras Lasso for sanitizing the code and UI, and for guidance throughout.

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -172,11 +172,11 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     """
     Called just after the scene is closed.
     """
+    # Clean up logic variables first. Avoids some Python console errors.
+    self.logic.initMemberVariables()
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
     if self.parent.isEntered:
       self.initializeParameterNode()
-    # Clean up logic variables too.
-    self.logic.initMemberVariables()
 
   def initializeParameterNode(self):
     """

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -1182,7 +1182,16 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
       # Get curve point radius by interpolating control point measurements
       # Need to compute manually until this method becomes available:
       #  radius = self.inputCenterlineNode.GetMeasurement('Radius').GetCurvePointValue(pointIndex)
-      controlPointFloatIndex = self.inputCenterlineNode.GetCurveWorld().GetPointData().GetArray('PedigreeIDs').GetValue(pointIndex)
+      if pointIndex < (self.getNumberOfPoints() - 1):
+        controlPointFloatIndex = self.inputCenterlineNode.GetCurveWorld().GetPointData().GetArray('PedigreeIDs').GetValue(pointIndex)
+      else:
+        """
+        Don't go beyond the last point with controlPointIndexB
+        Else,
+            radiusB = controlPointRadiusValues.GetValue(controlPointIndexB)
+        will fail.
+        """
+        controlPointFloatIndex = self.inputCenterlineNode.GetCurveWorld().GetPointData().GetArray('PedigreeIDs').GetValue(pointIndex - 1)
       controlPointIndexA = int(controlPointFloatIndex)
       controlPointIndexB = controlPointIndexA + 1
       controlPointRadiusValues = self.inputCenterlineNode.GetMeasurement('Radius').GetControlPointValues()

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -125,7 +125,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     # connections
     self.ui.applyButton.connect('clicked(bool)', self.onApplyButton)
 
-    self.ui.inputCenterlineSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
+    self.ui.inputCenterlineSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.logic.setInputCenterlineNode)
     self.ui.outputPlotSeriesSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
     self.ui.outputTableSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
 

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -266,6 +266,12 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.ui.showCrossSectionButton.setChecked(self.logic.showCrossSection)
 
     itemIndex = self.ui.outputPlotSeriesTypeComboBox.findData(self._parameterNode.GetParameter("OutputPlotSeriesType"))
+    """
+    This value is never rightly restored.
+    Prefer a default value rather than unknown.
+    """
+    if itemIndex < 0:
+        itemIndex = 0;
     self.ui.outputPlotSeriesTypeComboBox.setCurrentIndex(itemIndex)
 
     # Update button states

--- a/CurveCenterlineExtraction/CurveCenterlineExtraction.py
+++ b/CurveCenterlineExtraction/CurveCenterlineExtraction.py
@@ -595,10 +595,8 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     ffEffect = seWidgetEditor.activeEffect()
     ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
     ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
-    # ROI combobox in 'Flood filling' UI does not have a name.
-    roiComboBox = ffEffect.optionsFrame().children()[5]
     # +++ If an alien ROI is set, segmentation may fail and take an infinite time.
-    roiComboBox.setCurrentNode(None)
+    ffEffect.setParameter("ROINodeID", "")
 
     # Get input curve control points
     curveControlPoints = vtk.vtkPoints()
@@ -616,8 +614,8 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
         slicer.vtkMRMLSliceNode.JumpSlice(sliceWidget.sliceLogic().GetSliceNode(), *rasPoint)
         point3D = qt.QVector3D(rasPoint[0], rasPoint[1], rasPoint[2])
         point2D = ffEffect.rasToXy(point3D, sliceWidget)
-        xySliceViewCoord = (point2D.x(), point2D.y())
-        slicer.util.clickAndDrag(sliceWidget, start = xySliceViewCoord, end = xySliceViewCoord, steps = 1)
+        qIjkPoint = ffEffect.xyToIjk(point2D, sliceWidget, ffEffect.self().getClippedMasterImageData())
+        ffEffect.self().floodFillFromPoint((int(qIjkPoint.x()), int(qIjkPoint.y()), int(qIjkPoint.z())))
     
     # Switch off active effect
     seWidgetEditor.setActiveEffect(None)

--- a/CurveCenterlineExtraction/CurveCenterlineExtraction.py
+++ b/CurveCenterlineExtraction/CurveCenterlineExtraction.py
@@ -517,7 +517,7 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     """
     segmentation.SetReferenceImageGeometryParameterFromVolumeNode(volumeNode)
     
-    # If Segment Editor is not shown once, click() fails.
+    # Go to Segment Editor.
     mainWindow = slicer.util.mainWindow()
     mainWindow.moduleSelector().selectModule('SegmentEditor')
     

--- a/CurveCenterlineExtraction/CurveCenterlineExtraction.py
+++ b/CurveCenterlineExtraction/CurveCenterlineExtraction.py
@@ -541,11 +541,8 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     slicer.app.processEvents()
     seWidgetEditor.setActiveEffectByName("Split volume")
     svEffect = seWidgetEditor.activeEffect()
-    svWidgets = svEffect.optionsFrame().children()
-    svFillValueQSpinBox = svWidgets[6]
-    svSegmentEditorEffectApply = svEffect.optionsFrame().findChild(qt.QPushButton, "SegmentEditorEffectApply")
-    svFillValueQSpinBox.value = -1000
-    svSegmentEditorEffectApply.click()
+    svEffect.setParameter("FillValue", -1000)
+    svEffect.self().onApply()
     seWidgetEditor.setActiveEffectByName(None)
     
     # Get output split volume

--- a/CurveCenterlineExtraction/CurveCenterlineExtraction.py
+++ b/CurveCenterlineExtraction/CurveCenterlineExtraction.py
@@ -536,11 +536,6 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     tube.Update()
     segmentation.AddSegmentFromClosedSurfaceRepresentation(tube.GetOutput(), "TubeMask")
     seWidgetEditor.setCurrentSegmentID("TubeMask")
-    """
-    Split volume expects TubeMask to be visible.
-    Make it visible; a newly added segment is visible by default though.
-    """
-    segmentation.GetDisplayNode().SetSegmentVisibility("TubeMask", True)
     
     #---------------------- Split volume ---------------------
     slicer.util.showStatusMessage("Split volume")

--- a/CurveCenterlineExtraction/CurveCenterlineExtraction.py
+++ b/CurveCenterlineExtraction/CurveCenterlineExtraction.py
@@ -536,6 +536,11 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     tube.Update()
     segmentation.AddSegmentFromClosedSurfaceRepresentation(tube.GetOutput(), "TubeMask")
     seWidgetEditor.setCurrentSegmentID("TubeMask")
+    """
+    Split volume expects TubeMask to be visible.
+    Make it visible; a newly added segment is visible by default though.
+    """
+    segmentation.GetDisplayNode().SetSegmentVisibility("TubeMask", True)
     
     #---------------------- Split volume ---------------------
     slicer.util.showStatusMessage("Split volume")
@@ -543,7 +548,7 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     seWidgetEditor.setActiveEffectByName("Split volume")
     svEffect = seWidgetEditor.activeEffect()
     svEffect.setParameter("FillValue", -1000)
-    svEffect.setParameter("AllSegments", False)
+    svEffect.setParameter("ApplyToAllVisibleSegments", 0)
     svEffect.self().onApply()
     seWidgetEditor.setActiveEffectByName(None)
     
@@ -598,7 +603,7 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
     ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
     # +++ If an alien ROI is set, segmentation may fail and take an infinite time.
-    ffEffect.parameterSetNode().SetNodeReferenceID("ROINodeID", None)
+    ffEffect.parameterSetNode().SetNodeReferenceID("FloodFilling.ROI", None)
     ffEffect.updateGUIFromMRML()
 
     # Get input curve control points

--- a/CurveCenterlineExtraction/CurveCenterlineExtraction.py
+++ b/CurveCenterlineExtraction/CurveCenterlineExtraction.py
@@ -808,9 +808,9 @@ class SegmentEditorWidgets(ScriptedLoadableModule):
     Must be called when the first used effect is activated.
     """
     def resetMaskingWidgets(self):
-        self.maskModeComboBox.setCurrentIndex(0)
-        self.masterVolumeIntensityMaskCheckBox.checked = False
-        self.overwriteModeComboBox.setCurrentIndex(0)
+        self.widgetEditor.mrmlSegmentEditorNode().SetMaskMode(self.widgetEditor.mrmlSegmentEditorNode().PaintAllowedEverywhere)
+        self.widgetEditor.mrmlSegmentEditorNode().MasterVolumeIntensityMaskOff()
+        self.widgetEditor.mrmlSegmentEditorNode().SetOverwriteMode(self.widgetEditor.mrmlSegmentEditorNode().OverwriteAllSegments)
 
 class ExtractCenterlineWidgets(ScriptedLoadableModule):
     def __init__(self):

--- a/CurveCenterlineExtraction/CurveCenterlineExtraction.py
+++ b/CurveCenterlineExtraction/CurveCenterlineExtraction.py
@@ -596,14 +596,15 @@ class CurveCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
     ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
     # +++ If an alien ROI is set, segmentation may fail and take an infinite time.
-    ffEffect.setParameter("ROINodeID", "")
+    ffEffect.parameterSetNode().SetNodeReferenceID("ROINodeID", None)
+    ffEffect.updateGUIFromMRML()
 
     # Get input curve control points
     curveControlPoints = vtk.vtkPoints()
     self.inputCurveNode.GetControlPointPositionsWorld(curveControlPoints)
     numberOfCurveControlPoints = curveControlPoints.GetNumberOfPoints()
 
-    # Simulate a mouse click at curve control points. Ignore first and last point as the resulting segment would be a big lump. The voxels of split volume at -1000 would be included in the segment.
+    # Apply flood filling at curve control points. Ignore first and last point as the resulting segment would be a big lump. The voxels of split volume at -1000 would be included in the segment.
     for i in range(1, numberOfCurveControlPoints - 1):
         # Show progress in status bar. Helpful to wait.
         t = time.time()

--- a/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
+++ b/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
@@ -579,7 +579,7 @@ class FiducialCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     ffEffect = seWidgetEditor.activeEffect()
     ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
     ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
-    ffEffect.setParameter("ROINodeID", self.inputROINode.GetID() if self.inputROINode else "")
+    ffEffect.parameterSetNode().SetNodeReferenceID("ROINodeID", self.inputROINode.GetID() if self.inputROINode else None)
     # Reset segment editor masking widgets. Values set by previous work must not interfere here.
     self.segmentEditorWidgets.resetMaskingWidgets()
     

--- a/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
+++ b/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
@@ -579,10 +579,7 @@ class FiducialCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     ffEffect = seWidgetEditor.activeEffect()
     ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
     ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
-    # ffEffect.optionsFrame().children()
-    # ROI combobox in 'Flood filling' UI does not have a name.
-    roiComboBox = ffEffect.optionsFrame().children()[5]
-    roiComboBox.setCurrentNode(self.inputROINode)
+    ffEffect.setParameter("ROINodeID", self.inputROINode.GetID() if self.inputROINode else "")
     # Reset segment editor masking widgets. Values set by previous work must not interfere here.
     self.segmentEditorWidgets.resetMaskingWidgets()
     

--- a/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
+++ b/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
@@ -542,7 +542,7 @@ class FiducialCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     seWidgetEditor.setSegmentationNode(segmentation)
     seWidgetEditor.setMasterVolumeNode(volumeNode)
     
-    # If Segment Editor is not shown once, click() fails.
+    # Go to Segment Editor.
     mainWindow = slicer.util.mainWindow()
     mainWindow.moduleSelector().selectModule('SegmentEditor')
     

--- a/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
+++ b/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
@@ -583,7 +583,7 @@ class FiducialCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     # Reset segment editor masking widgets. Values set by previous work must not interfere here.
     self.segmentEditorWidgets.resetMaskingWidgets()
     
-    # For each fiducial point, simulate a mouse click.
+    # Apply flood filling at each fiducial point.
     points=vtk.vtkPoints()
     self.inputFiducialNode.GetControlPointPositionsWorld(points)
     numberOfFiducialControlPoints = points.GetNumberOfPoints()
@@ -597,11 +597,8 @@ class FiducialCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
         slicer.vtkMRMLSliceNode.JumpSlice(sliceWidget.sliceLogic().GetSliceNode(), *rasPoint)
         point3D = qt.QVector3D(rasPoint[0], rasPoint[1], rasPoint[2])
         point2D = ffEffect.rasToXy(point3D, sliceWidget)
-        xySliceViewCoord = (point2D.x(), point2D.y())
-        """
-        https://discourse.slicer.org/t/how-to-call-the-islands-function-of-the-segment-editor-from-a-python-script-with-keep-selected-island/14763
-        """
-        slicer.util.clickAndDrag(sliceWidget, start = xySliceViewCoord, end = xySliceViewCoord, steps = 1)
+        qIjkPoint = ffEffect.xyToIjk(point2D, sliceWidget, ffEffect.self().getClippedMasterImageData())
+        ffEffect.self().floodFillFromPoint((int(qIjkPoint.x()), int(qIjkPoint.y()), int(qIjkPoint.z())))
     
     # Switch off active effect
     seWidgetEditor.setActiveEffect(None)

--- a/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
+++ b/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
@@ -580,6 +580,7 @@ class FiducialCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
     ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
     ffEffect.parameterSetNode().SetNodeReferenceID("ROINodeID", self.inputROINode.GetID() if self.inputROINode else None)
+    ffEffect.updateGUIFromMRML()
     # Reset segment editor masking widgets. Values set by previous work must not interfere here.
     self.segmentEditorWidgets.resetMaskingWidgets()
     

--- a/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
+++ b/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
@@ -579,7 +579,7 @@ class FiducialCenterlineExtractionLogic(ScriptedLoadableModuleLogic):
     ffEffect = seWidgetEditor.activeEffect()
     ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
     ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
-    ffEffect.parameterSetNode().SetNodeReferenceID("ROINodeID", self.inputROINode.GetID() if self.inputROINode else None)
+    ffEffect.parameterSetNode().SetNodeReferenceID("FloodFilling.ROI", self.inputROINode.GetID() if self.inputROINode else None)
     ffEffect.updateGUIFromMRML()
     # Reset segment editor masking widgets. Values set by previous work must not interfere here.
     self.segmentEditorWidgets.resetMaskingWidgets()

--- a/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
+++ b/FiducialCenterlineExtraction/FiducialCenterlineExtraction.py
@@ -752,9 +752,9 @@ class SegmentEditorWidgets(ScriptedLoadableModule):
     Must be called when the first used effect is activated.
     """
     def resetMaskingWidgets(self):
-        self.maskModeComboBox.setCurrentIndex(0)
-        self.masterVolumeIntensityMaskCheckBox.checked = False
-        self.overwriteModeComboBox.setCurrentIndex(0)
+        self.widgetEditor.mrmlSegmentEditorNode().SetMaskMode(self.widgetEditor.mrmlSegmentEditorNode().PaintAllowedEverywhere)
+        self.widgetEditor.mrmlSegmentEditorNode().MasterVolumeIntensityMaskOff()
+        self.widgetEditor.mrmlSegmentEditorNode().SetOverwriteMode(self.widgetEditor.mrmlSegmentEditorNode().OverwriteAllSegments)
 
 class ExtractCenterlineWidgets(ScriptedLoadableModule):
     def __init__(self):


### PR DESCRIPTION
Reduce UI simulation

Adapt to remote changes in SegmentEditorExtra Effects :

 - Use FloodFilling.ROI parameter to set the ROI combobox
 - Use ApplyToAllVisibleSegments of SplitVolume to limit to selected segment

Other local changes to reduce UI simulation :
 - Use functions of
 slicer.modules.SegmentEditorWidget.editor.mrmlSegmentEditorNode()
 to reset masking options
 - Use floodFillFromPoint to initiate flood filling
 - Don't look for stray volume nodes in the subject hierarchy folder created
 by Split Volume, since we can split on a selected segment

Other UI simulations will be addressed later.
