### PR TITLE
Use a markups Shape::Tube node to limit a zone of interest.

### DIFF
--- a/Docs/GuidedArterySegmentation.md
+++ b/Docs/GuidedArterySegmentation.md
@@ -16,6 +16,10 @@ The '[Extract centerline](https://github.com/vmtk/SlicerExtension-VMTK/tree/mast
 
 At least 3 control points are required. All control points must lie in the contrasted lumen, simulating the arterial axis. The first and last points will be endpoints to ‘Extract centerline’ module, and are not used for segmentation. It is therefore helpful that the second control point be reasonably close to the first point, and that the before last one be close to the last point. The input curve will be hidden if centerlines are requested.
 
+### Input markups shape node
+
+A Shape::Tube node can be used as region of interest. It can be drawn to represent the arterial wall. Lumen segmentation is then carried out inside this tube. If a Shape::Tube node is used, the tube diameter parameter below is ignored. This node is available in [ExtraMarkups](https://github.com/chir-set/SlicerExtraMarkups) extension.
+
 ### Input slice node
 
 The 'Flood filling' effect will be applied at each point in this slice view. The current offset will be changed consequently.

--- a/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
+++ b/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>354</width>
-    <height>537</height>
+    <width>495</width>
+    <height>710</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -81,9 +81,9 @@ The control points are assumed to be on the contrasted lumen.</string>
       <item row="7" column="1">
        <widget class="QDoubleSpinBox" name="tubeDiameterSpinBox">
         <property name="toolTip">
-         <string>Specify a value slightly above the maximum estimated diameter of the target tube.
+         <string>Specify a value slightly above the maximum estimated diameter of the target artery.
 
-This value is passed to 'Draw tube' segment editor effect.</string>
+If a Shape::Tube node is specified below, this parameter is ignored.</string>
         </property>
         <property name="locale">
          <locale language="English" country="UnitedStates"/>
@@ -136,7 +136,7 @@ This value is passed to 'Draw tube' segment editor effect.</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <layout class="QHBoxLayout" name="inputSliceNodeLayout">
         <item>
          <widget class="qMRMLNodeComboBox" name="inputSliceNodeSelector">
@@ -177,7 +177,7 @@ This value is passed to 'Draw tube' segment editor effect.</string>
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="inputSliceNodeLabel">
         <property name="locale">
          <locale language="English" country="UnitedStates"/>
@@ -186,6 +186,87 @@ This value is passed to 'Draw tube' segment editor effect.</string>
          <string>Slice node:</string>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleGroupBox" name="extentCollapsibleGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="locale">
+      <locale language="English" country="UnitedStates"/>
+     </property>
+     <property name="title">
+      <string>Alternative extent</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <item>
+       <widget class="QLabel" name="extentLabel">
+        <property name="text">
+         <string>Use a Shape::Tube node to limit the circumferential
+extent, instead of a fixed diameter tube.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QFormLayout" name="extentFormLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="inputShapeNodeLabel">
+          <property name="text">
+           <string>Tube node:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="qMRMLNodeComboBox" name="inputShapeSelector">
+          <property name="toolTip">
+           <string>Limit the region of interest to this Shape::Tube node.
+
+If specified, the regular tube diameter above is ignored.</string>
+          </property>
+          <property name="nodeTypes">
+           <stringlist notr="true">
+            <string>vtkMRMLMarkupsShapeNode</string>
+           </stringlist>
+          </property>
+          <property name="hideChildNodeTypes">
+           <stringlist notr="true"/>
+          </property>
+          <property name="noneEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="addEnabled">
+           <bool>false</bool>
+          </property>
+          <property name="editEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="renameEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="interactionNodeSingletonTag">
+           <string notr="true"/>
+          </property>
+          <property name="selectNodeUponCreation">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -401,6 +482,22 @@ Output nodes from the last run will be removed.</string>
     <hint type="destinationlabel">
      <x>240</x>
      <y>164</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>GuidedArterySegmentation</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>inputShapeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>176</x>
+     <y>268</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>240</x>
+     <y>114</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
The initial zone of interest is a regular tube.

This patch allows to use a markups Shape::Tube node as 'ROI', as a second zone limiting method.

@lassoan 
