### PR TITLE
With wall surface- Fix Windows build : Try 2

### DIFF
--- a/CrossSectionAnalysis/Logic/CMakeLists.txt
+++ b/CrossSectionAnalysis/Logic/CMakeLists.txt
@@ -18,6 +18,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${VTK_LIBRARIES}
+  vtkSlicerShapeModuleMRML
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Link extruded logic of CrossSectionAnalysis to Shape MRML library.

The build error message _seems_ to indicate this link is missing on Windows.

--------------------------------------------------------------------------------------------------
N.B. : without any means for a Windows build on my machines, a definite resolution is hard to find. This will probably be the last try.