### PR TITLE
BUG: Fix ExtractCenterline to follow VTK changes

### DIFF
--- a/ExtractCenterline/ExtractCenterline.py
+++ b/ExtractCenterline/ExtractCenterline.py
@@ -955,8 +955,8 @@ class ExtractCenterlineLogic(ScriptedLoadableModuleLogic):
         # Add current cell as a curve node
         assignAttribute = vtk.vtkAssignAttribute()
         assignAttribute.SetInputData(mergedCenterlines)
-        assignAttribute.Assign(self.groupIdsArrayName, vtk.vtkDataSetAttributes.SCALARS,
-                               vtk.vtkAssignAttribute.CELL_DATA)
+        assignAttribute.Assign(self.groupIdsArrayName, vtk.vtkDataSetAttributes.SCALARS, vtk.vtkAssignAttribute.CELL_DATA)
+
         thresholder = vtk.vtkThreshold()
         thresholder.SetInputConnection(assignAttribute.GetOutputPort())
         groupId = mergedCenterlines.GetCellData().GetArray(self.groupIdsArrayName).GetValue(cellId)
@@ -989,7 +989,10 @@ class ExtractCenterlineLogic(ScriptedLoadableModuleLogic):
 
         curveNode.SetAttribute("CellId", str(cellId))
         curveNode.SetAttribute("GroupId", str(groupId))
-        curveNode.SetControlPointPositionsWorld(thresholder.GetOutput().GetPoints())
+
+        # Add control points in the order as appears in the cell (line) because the point IDs are not in the
+        # correct order (the branching points always have the highest ID).
+        curveNode.SetControlPointPositionsWorld(thresholder.GetOutput().GetCell(0).GetPoints())
 
         self._addCurveMeasurementArray(curveNode, thresholder.GetOutput().GetPointData().GetArray('Radius'))
 


### PR DESCRIPTION
The ExtractCenterline function has been broken since the Slicer commit https://github.com/Slicer/Slicer/commit/d12bcabc2b777512ae310c2117fd2195ab0cccfb (ENH: Update VTK from 9.1.20220125 to 9.2.20230607).

The issue was that vtkThreshold yielded an unstructured grid, the point IDs of which were not in order. To fix the problem, the points in the order which they appear in the output cell are used in the centerline curve.