### PR TITLE
Use the new parameter node wrapper and minor improvements.

### DIFF
--- a/BranchClipper/Resources/UI/qSlicerBranchClipperWidget.ui
+++ b/BranchClipper/Resources/UI/qSlicerBranchClipperWidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>qSlicerBranchClipperFooBarWidget</class>
- <widget class="QWidget" name="qSlicerBranchClipperFooBarWidget">
+ <class>qSlicerBranchClipperWidget</class>
+ <widget class="QWidget" name="qSlicerBranchClipperWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -18,7 +18,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QPushButton" name="FooBarButton">
+    <widget class="QPushButton" name="Button">
      <property name="text">
       <string>Foo Bar</string>
      </property>

--- a/BranchClipper/Widgets/CMakeLists.txt
+++ b/BranchClipper/Widgets/CMakeLists.txt
@@ -8,16 +8,16 @@ set(${KIT}_INCLUDE_DIRECTORIES
   )
 
 set(${KIT}_SRCS
-  qSlicer${MODULE_NAME}FooBarWidget.cxx
-  qSlicer${MODULE_NAME}FooBarWidget.h
+  qSlicer${MODULE_NAME}Widget.cxx
+  qSlicer${MODULE_NAME}Widget.h
   )
 
 set(${KIT}_MOC_SRCS
-  qSlicer${MODULE_NAME}FooBarWidget.h
+  qSlicer${MODULE_NAME}Widget.h
   )
 
 set(${KIT}_UI_SRCS
-  ../Resources/UI/qSlicer${MODULE_NAME}FooBarWidget.ui
+  ../Resources/UI/qSlicer${MODULE_NAME}Widget.ui
   )
 
 set(${KIT}_RESOURCES

--- a/BranchClipper/Widgets/qSlicerBranchClipperWidget.cxx
+++ b/BranchClipper/Widgets/qSlicerBranchClipperWidget.cxx
@@ -18,55 +18,55 @@
 
 ==============================================================================*/
 
-// FooBar Widgets includes
-#include "qSlicerBranchClipperFooBarWidget.h"
-#include "ui_qSlicerBranchClipperFooBarWidget.h"
+//  Widgets includes
+#include "qSlicerBranchClipperWidget.h"
+#include "ui_qSlicerBranchClipperWidget.h"
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_BranchClipper
-class qSlicerBranchClipperFooBarWidgetPrivate
-  : public Ui_qSlicerBranchClipperFooBarWidget
+class qSlicerBranchClipperWidgetPrivate
+  : public Ui_qSlicerBranchClipperWidget
 {
-  Q_DECLARE_PUBLIC(qSlicerBranchClipperFooBarWidget);
+  Q_DECLARE_PUBLIC(qSlicerBranchClipperWidget);
 protected:
-  qSlicerBranchClipperFooBarWidget* const q_ptr;
+  qSlicerBranchClipperWidget* const q_ptr;
 
 public:
-  qSlicerBranchClipperFooBarWidgetPrivate(
-    qSlicerBranchClipperFooBarWidget& object);
-  virtual void setupUi(qSlicerBranchClipperFooBarWidget*);
+  qSlicerBranchClipperWidgetPrivate(
+    qSlicerBranchClipperWidget& object);
+  virtual void setupUi(qSlicerBranchClipperWidget*);
 };
 
 // --------------------------------------------------------------------------
-qSlicerBranchClipperFooBarWidgetPrivate
-::qSlicerBranchClipperFooBarWidgetPrivate(
-  qSlicerBranchClipperFooBarWidget& object)
+qSlicerBranchClipperWidgetPrivate
+::qSlicerBranchClipperWidgetPrivate(
+  qSlicerBranchClipperWidget& object)
   : q_ptr(&object)
 {
 }
 
 // --------------------------------------------------------------------------
-void qSlicerBranchClipperFooBarWidgetPrivate
-::setupUi(qSlicerBranchClipperFooBarWidget* widget)
+void qSlicerBranchClipperWidgetPrivate
+::setupUi(qSlicerBranchClipperWidget* widget)
 {
-  this->Ui_qSlicerBranchClipperFooBarWidget::setupUi(widget);
+  this->Ui_qSlicerBranchClipperWidget::setupUi(widget);
 }
 
 //-----------------------------------------------------------------------------
-// qSlicerBranchClipperFooBarWidget methods
+// qSlicerBranchClipperWidget methods
 
 //-----------------------------------------------------------------------------
-qSlicerBranchClipperFooBarWidget
-::qSlicerBranchClipperFooBarWidget(QWidget* parentWidget)
+qSlicerBranchClipperWidget
+::qSlicerBranchClipperWidget(QWidget* parentWidget)
   : Superclass( parentWidget )
-  , d_ptr( new qSlicerBranchClipperFooBarWidgetPrivate(*this) )
+  , d_ptr( new qSlicerBranchClipperWidgetPrivate(*this) )
 {
-  Q_D(qSlicerBranchClipperFooBarWidget);
+  Q_D(qSlicerBranchClipperWidget);
   d->setupUi(this);
 }
 
 //-----------------------------------------------------------------------------
-qSlicerBranchClipperFooBarWidget
-::~qSlicerBranchClipperFooBarWidget()
+qSlicerBranchClipperWidget
+::~qSlicerBranchClipperWidget()
 {
 }

--- a/BranchClipper/Widgets/qSlicerBranchClipperWidget.h
+++ b/BranchClipper/Widgets/qSlicerBranchClipperWidget.h
@@ -18,35 +18,35 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerBranchClipperFooBarWidget_h
-#define __qSlicerBranchClipperFooBarWidget_h
+#ifndef __qSlicerBranchClipperWidget_h
+#define __qSlicerBranchClipperWidget_h
 
 // Qt includes
 #include <QWidget>
 
-// FooBar Widgets includes
+//  Widgets includes
 #include "qSlicerBranchClipperModuleWidgetsExport.h"
 
-class qSlicerBranchClipperFooBarWidgetPrivate;
+class qSlicerBranchClipperWidgetPrivate;
 
 /// \ingroup Slicer_QtModules_BranchClipper
-class Q_SLICER_MODULE_BRANCHCLIPPER_WIDGETS_EXPORT qSlicerBranchClipperFooBarWidget
+class Q_SLICER_MODULE_BRANCHCLIPPER_WIDGETS_EXPORT qSlicerBranchClipperWidget
   : public QWidget
 {
   Q_OBJECT
 public:
   typedef QWidget Superclass;
-  qSlicerBranchClipperFooBarWidget(QWidget *parent=0);
-  ~qSlicerBranchClipperFooBarWidget() override;
+  qSlicerBranchClipperWidget(QWidget *parent=0);
+  ~qSlicerBranchClipperWidget() override;
 
 protected slots:
 
 protected:
-  QScopedPointer<qSlicerBranchClipperFooBarWidgetPrivate> d_ptr;
+  QScopedPointer<qSlicerBranchClipperWidgetPrivate> d_ptr;
 
 private:
-  Q_DECLARE_PRIVATE(qSlicerBranchClipperFooBarWidget);
-  Q_DISABLE_COPY(qSlicerBranchClipperFooBarWidget);
+  Q_DECLARE_PRIVATE(qSlicerBranchClipperWidget);
+  Q_DISABLE_COPY(qSlicerBranchClipperWidget);
 };
 
 #endif

--- a/CenterlineDisassembly/CenterlineDisassembly.py
+++ b/CenterlineDisassembly/CenterlineDisassembly.py
@@ -174,7 +174,7 @@ class CenterlineDisassemblyWidget(ScriptedLoadableModuleWidget, VTKObservationMi
             # Compute output
             component = self.ui.componentComboBox.currentData
             shFolderId = -1
-            if component == 1:
+            if component == BIFURCATIONS_ITEM_ID:
                 bifurcationsPolyDatas = self.logic.processGroupIds(self._parameterNode.inputCenterline, True)
                 if (len(bifurcationsPolyDatas)):
                     shFolderId = self._createSubjectHierarchyFolderNode(self.ui.componentComboBox.currentText)
@@ -182,7 +182,7 @@ class CenterlineDisassemblyWidget(ScriptedLoadableModuleWidget, VTKObservationMi
                     bifurcationModel = slicer.modules.models.logic().AddModel(bifurcationPolyData)
                     bifurcationModel.GetDisplayNode().SetColor([0.67, 1.0, 1.0])
                     self._reparentNodeToSubjectHierarchyFolderNode(shFolderId, bifurcationModel)
-            elif component == 2:
+            elif component == BRANCHES_ITEM_ID:
                 branchesPolyDatas = self.logic.processGroupIds(self._parameterNode.inputCenterline, False)
                 if (len(branchesPolyDatas)):
                     shFolderId = self._createSubjectHierarchyFolderNode(self.ui.componentComboBox.currentText)
@@ -190,7 +190,7 @@ class CenterlineDisassemblyWidget(ScriptedLoadableModuleWidget, VTKObservationMi
                     branchModel = slicer.modules.models.logic().AddModel(branchPolyData)
                     branchModel.GetDisplayNode().SetColor([0.0, 0.0, 1.0])
                     self._reparentNodeToSubjectHierarchyFolderNode(shFolderId, branchModel)
-            elif component == 3:
+            elif component == CENTERLINES_ITEM_ID:
                 centerlinesPolyDatas = self.logic.processCenterlineIds(self._parameterNode.inputCenterline)
                 if (len(centerlinesPolyDatas)):
                     shFolderId = self._createSubjectHierarchyFolderNode(self.ui.componentComboBox.currentText)

--- a/GuidedArterySegmentation/GuidedArterySegmentation.py
+++ b/GuidedArterySegmentation/GuidedArterySegmentation.py
@@ -1,9 +1,20 @@
-import os
-import unittest
 import logging
-import vtk, qt, ctk, slicer
+import os
+from typing import Annotated, Optional
+
+import vtk, ctk, qt
+
+import slicer
+from slicer.i18n import tr as _
+from slicer.i18n import translate
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
+from slicer.parameterNodeWrapper import (
+    parameterNodeWrapper,
+    WithinRange,
+)
+
+from slicer import vtkMRMLScalarVolumeNode
 
 #
 # GuidedArterySegmentation
@@ -14,7 +25,7 @@ class GuidedArterySegmentation(ScriptedLoadableModule):
   https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
-  def __init__(self, parent):
+  def __init__(self, parent) -> None:
     ScriptedLoadableModule.__init__(self, parent)
     self.parent.title = "Guided artery segmentation"
     self.parent.categories = ["Vascular Modeling Toolkit"]
@@ -37,6 +48,26 @@ and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR0132
 """
 
 #
+# GuidedArterySegmentationParameterNode
+#
+
+@parameterNodeWrapper
+class GuidedArterySegmentationParameterNode:
+  # N.B. - we cannot reference the Shape node here since it is an additional markups.
+  #      - either the module is not loaded or the parameter node complains (1). 
+  inputCurveNode: slicer.vtkMRMLMarkupsCurveNode
+  inputSliceNode: slicer.vtkMRMLSliceNode
+  tubeDiameter: float = 8.0
+  intensityTolerance: int = 100
+  neighbourhoodSize: float = 2.0
+  extractCenterlines: bool = False
+  outputSegmentation: slicer.vtkMRMLSegmentationNode
+  # These do not have widget counterparts.
+  outputFiducialNode: slicer.vtkMRMLMarkupsFiducialNode # 'Extract centerline' endpoints
+  outputCenterlineModel: slicer.vtkMRMLModelNode
+  outputCenterlineCurve: slicer.vtkMRMLMarkupsCurveNode
+
+#
 # GuidedArterySegmentationWidget
 #
 
@@ -45,7 +76,7 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
   https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
-  def __init__(self, parent=None):
+  def __init__(self, parent=None) -> None:
     """
     Called when the user opens the module the first time and the widget is initialized.
     """
@@ -53,9 +84,9 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
     VTKObservationMixin.__init__(self)  # needed for parameter node observation
     self.logic = None
     self._parameterNode = None
-    self._updatingGUIFromParameterNode = False
+    self._parameterNodeGuiTag = None
 
-  def setup(self):
+  def setup(self) -> None:
     """
     Called when the user opens the module the first time and the widget is initialized.
     """
@@ -85,24 +116,9 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
-    # These connections ensure that whenever user changes some settings on the GUI, that is saved in the MRML scene
-    # (in the selected parameter node).
-    self.ui.inputCurveSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
-    self.ui.inputShapeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
-    self.ui.inputSliceNodeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
-    self.ui.tubeDiameterSpinBox.connect("valueChanged(double)", self.updateParameterNodeFromGUI)
-    self.ui.intensityToleranceSpinBox.connect("valueChanged(int)", self.updateParameterNodeFromGUI)
-    self.ui.neighbourhoodSizeDoubleSpinBox.connect("valueChanged(double)", self.updateParameterNodeFromGUI)
-    self.ui.extractCenterlinesCheckBox.connect("toggled(bool)", self.updateParameterNodeFromGUI)
-    
     # Application connections
     self.ui.inputCurveSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onCurveNode)
     self.ui.inputShapeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onShapeNode)
-    self.ui.inputSliceNodeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onSliceNode)
-    self.ui.tubeDiameterSpinBox.connect("valueChanged(double)", self.logic.setTubeDiameter)
-    self.ui.intensityToleranceSpinBox.connect("valueChanged(int)", self.logic.setIntensityTolerance)
-    self.ui.neighbourhoodSizeDoubleSpinBox.connect("valueChanged(double)", self.logic.setNeighbourhoodSize)
-    self.ui.extractCenterlinesCheckBox.connect("toggled(bool)", self.logic.setExtractCenterlines)
     self.ui.restoreSliceViewToolButton.connect("clicked()", self.onRestoreSliceViews)
 
     # Buttons
@@ -126,7 +142,7 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
         traceback.print_exc()
       
     
-  def installExtensionFromServer(self, extensionName):
+  def installExtensionFromServer(self, extensionName) -> None:
     # https://slicer.readthedocs.io/en/latest/developer_guide/script_repository.html#download-and-install-extension
     em = slicer.app.extensionsManagerModel()
     if not em.isExtensionInstalled(extensionName):
@@ -146,67 +162,56 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
       if reply:
         slicer.util.restart()
 
-  def inform(self, message):
+  def inform(self, message) -> None:
     slicer.util.showStatusMessage(message, 3000)
     logging.info(message)
 
-  def onCurveNode(self, node):
+  def onCurveNode(self, node) -> None:
+    self._parameterNode.inputCurveNode = node
     if node is None:
-        self.logic.setInputCurveNode(None)
         return
     numberOfControlPoints = node.GetNumberOfControlPoints()
-    if numberOfControlPoints < 2: # Possible ?
-        self.inform("Curve node must have at least 2 points.")
-        self.ui.inputCurveSelector.setCurrentNode(None)
-        self.logic.setInputCurveNode(None)
+    if numberOfControlPoints < 3:
+        self.inform("Curve node must have at least 3 points.")
+        self._parameterNode.inputCurveNode = None
         return
-    self.logic.setInputCurveNode(node)
     # Update UI with previous referenced segmentation. May be changed before logic.process().
     referencedSegmentationNode = node.GetNodeReference("OutputSegmentation")
     if referencedSegmentationNode:
-        self.ui.outputSegmentationSelector.setCurrentNode(referencedSegmentationNode)
+        self._parameterNode.outputSegmentation = referencedSegmentationNode
     # Show last known volume used for segmentation.
     referencedInputVolume = node.GetNodeReference("InputVolumeNode")
     self.updateSliceViews(referencedInputVolume)
     # Reuse last known parameters
     self.updateGUIParametersFromInputNode()
   
-  def onShapeNode(self, node):
+  def onShapeNode(self, node) -> None:
     if node is None:
-        self.logic.setInputShapeNode(None)
         self.ui.tubeDiameterSpinBoxLabel.setVisible(True)
         self.ui.tubeDiameterSpinBox.setVisible(True)
         return
     if node.GetShapeName() != slicer.vtkMRMLMarkupsShapeNode().Tube:
         self.inform("Shape node is not a Tube.")
-        self.ui.inputShapeSelector.setCurrentNode(None)
-        self.logic.setInputShapeNode(None)
+        self._shapeNode = None
         self.ui.tubeDiameterSpinBoxLabel.setVisible(True)
         self.ui.tubeDiameterSpinBox.setVisible(True)
         return
     numberOfControlPoints = node.GetNumberOfControlPoints()
     if numberOfControlPoints < 4:
         self.inform("Shape node must have at least 4 points.")
-        self.ui.inputShapeSelector.setCurrentNode(None)
-        self.logic.setInputShapeNode(None)
+        self._shapeNode = None
         self.ui.tubeDiameterSpinBoxLabel.setVisible(True)
         self.ui.tubeDiameterSpinBox.setVisible(True)
         return
-    self.logic.setInputShapeNode(node)
+    self.logic.setShapeNode(node)
     self.ui.tubeDiameterSpinBoxLabel.setVisible(False)
     self.ui.tubeDiameterSpinBox.setVisible(False)
-    
-  def onSliceNode(self, node):
-    if node is None:
-        self.logic.setInputSliceNode(None)
-        return
-    self.logic.setInputSliceNode(node)
 
-  def updateSliceViews(self, node):
+  def updateSliceViews(self, node) -> None:
     # Don't allow None node, is very annoying.
     if not node:
         return
-    sliceNode = self.logic.inputSliceNode
+    sliceNode = self._parameterNode.inputSliceNode
     if not sliceNode:
         return
     # Don't upset UI if we have the right volume node
@@ -224,42 +229,43 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
         else:
             sliceCompositeNode.SetBackgroundVolumeID(None)
 
-  def onRestoreSliceViews(self):
+  def onRestoreSliceViews(self) -> None:
     # Show last known volume used for segmentation.
-    inputCurveNode = self.ui.inputCurveSelector.currentNode()
-    if not inputCurveNode:
+    if not self._parameterNode.inputCurveNode:
         return
-    referencedInputVolume = inputCurveNode.GetNodeReference("InputVolumeNode")
+    referencedInputVolume = self._parameterNode.inputCurveNode.GetNodeReference("InputVolumeNode")
     self.updateSliceViews(referencedInputVolume)
     
-  def cleanup(self):
+  def cleanup(self) -> None:
     """
     Called when the application closes and the module widget is destroyed.
     """
     self.removeObservers()
 
-  def enter(self):
+  def enter(self) -> None:
     """
     Called each time the user opens this module.
     """
     # Make sure parameter node exists and observed
     self.initializeParameterNode()
 
-  def exit(self):
+  def exit(self) -> None:
     """
     Called each time the user opens a different module.
     """
-    # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
-    self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+    # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
+    if self._parameterNode:
+      self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
+      self._parameterNodeGuiTag = None
 
-  def onSceneStartClose(self, caller, event):
+  def onSceneStartClose(self, caller, event) -> None:
     """
     Called just before the scene is closed.
     """
     # Parameter node will be reset, do not use it anymore
     self.setParameterNode(None)
 
-  def onSceneEndClose(self, caller, event):
+  def onSceneEndClose(self, caller, event) -> None:
     """
     Called just after the scene is closed.
     """
@@ -268,7 +274,7 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
       self.initializeParameterNode()
     self.logic.initMemberVariables()
 
-  def initializeParameterNode(self):
+  def initializeParameterNode(self) -> None:
     """
     Ensure parameter node exists and observed.
     """
@@ -277,160 +283,108 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
 
     self.setParameterNode(self.logic.getParameterNode())
 
-  def setParameterNode(self, inputParameterNode):
+  def setParameterNode(self, inputParameterNode) -> None:
     """
     Set and observe parameter node.
     Observation is needed because when the parameter node is changed then the GUI must be updated immediately.
     """
 
-    if inputParameterNode:
-      self.logic.setDefaultParameters(inputParameterNode)
-
-    # Unobserve previously selected parameter node and add an observer to the newly selected.
-    # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
-    # those are reflected immediately in the GUI.
-    if self._parameterNode is not None:
-      self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+    if self._parameterNode:
+      self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
     self._parameterNode = inputParameterNode
-    if self._parameterNode is not None:
-      self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
-
-    # Initial GUI update
-    self.updateGUIFromParameterNode()
-
-  def updateGUIFromParameterNode(self, caller=None, event=None):
-    """
-    This method is called whenever parameter node is changed.
-    The module GUI is updated to show the current state of the parameter node.
-    """
-
-    if self._parameterNode is None or self._updatingGUIFromParameterNode:
-      return
-
-    # Make sure GUI changes do not call updateParameterNodeFromGUI (it could cause infinite loop)
-    self._updatingGUIFromParameterNode = True
-
-    # Update node selectors and sliders
-    self.ui.inputCurveSelector.setCurrentNode(self._parameterNode.GetNodeReference("InputCurveNode"))
-    self.ui.inputShapeSelector.setCurrentNode(self._parameterNode.GetNodeReference("InputShapeNode"))
-    self.ui.inputSliceNodeSelector.setCurrentNode(self._parameterNode.GetNodeReference("InputSliceNode"))
-    self.ui.tubeDiameterSpinBox.value = float(self._parameterNode.GetParameter("TubeDiameter"))
-    self.ui.intensityToleranceSpinBox.value = int(self._parameterNode.GetParameter("IntensityTolerance"))
-    self.ui.neighbourhoodSizeDoubleSpinBox.value = float(self._parameterNode.GetParameter("NeighbourhoodSize"))
-    self.ui.extractCenterlinesCheckBox.setChecked (self._parameterNode.GetParameter("ExtractCenterlines") == "True")
-
-    # All the GUI updates are done
-    self._updatingGUIFromParameterNode = False
-
-  def updateParameterNodeFromGUI(self, caller=None, event=None):
-    """
-    This method is called when the user makes any change in the GUI.
-    The changes are saved into the parameter node (so that they are restored when the scene is saved and loaded).
-    """
-
-    if self._parameterNode is None or self._updatingGUIFromParameterNode:
-      return
-
-    wasModified = self._parameterNode.StartModify()  # Modify all properties in a single batch
-
-    self._parameterNode.SetNodeReferenceID("InputCurveNode", self.ui.inputCurveSelector.currentNodeID)
-    self._parameterNode.SetNodeReferenceID("InputShapeNode", self.ui.inputShapeSelector.currentNodeID)
-    self._parameterNode.SetNodeReferenceID("InputSliceNode", self.ui.inputSliceNodeSelector.currentNodeID)
-    self._parameterNode.SetParameter("TubeDiameter", str(self.ui.tubeDiameterSpinBox.value))
-    self._parameterNode.SetParameter("IntensityTolerance", str(self.ui.intensityToleranceSpinBox.value))
-    self._parameterNode.SetParameter("NeighbourhoodSize", str(self.ui.neighbourhoodSizeDoubleSpinBox.value))
-    self._parameterNode.SetParameter("ExtractCenterlines", str(self.ui.extractCenterlinesCheckBox.isChecked()))
-
-    self._parameterNode.EndModify(wasModified)
+    if self._parameterNode:
+      # Note: in the .ui file, a Qt dynamic property called "SlicerParameterName" is set on each
+      # ui element that needs connection.
+      self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
 
   """
   Let each one trace last used parameter values and output nodes.
   These can be restored when an input curve is selected again.
   """
-  def UpdateInputNodeWithThisOutputNode(self, outputNode, referenceID):
+  def UpdateInputNodeWithThisOutputNode(self, outputNode, referenceID) -> None:
     outputNodeID = ""
     if outputNode:
         outputNodeID = outputNode.GetID()
-    self.logic.inputCurveNode.SetNodeReferenceID(referenceID, outputNodeID)
+    self._parameterNode.inputCurveNode.SetNodeReferenceID(referenceID, outputNodeID)
     
-  def UpdateInputNodeWithOutputNodes(self):
-    if not self.logic.inputCurveNode:
+  def UpdateInputNodeWithOutputNodes(self) -> None:
+    if not self._parameterNode.inputCurveNode:
         return
-    wasModified = self.logic.inputCurveNode.StartModify()
-    self.UpdateInputNodeWithThisOutputNode(self.logic.outputFiducialNode, "OutputFiducialNode")
-    self.UpdateInputNodeWithThisOutputNode(self.logic.outputSegmentation, "OutputSegmentation")
-    self.UpdateInputNodeWithThisOutputNode(self.logic.outputCenterlineModel, "OutputCenterlineModel")
-    self.UpdateInputNodeWithThisOutputNode(self.logic.outputCenterlineCurve, "OutputCenterlineCurve")
-    self.logic.inputCurveNode.EndModify(wasModified)
+    wasModified = self._parameterNode.inputCurveNode.StartModify()
+    self.UpdateInputNodeWithThisOutputNode(self._parameterNode.outputFiducialNode, "OutputFiducialNode")
+    self.UpdateInputNodeWithThisOutputNode(self._parameterNode.outputSegmentation, "OutputSegmentation")
+    self.UpdateInputNodeWithThisOutputNode(self._parameterNode.outputCenterlineModel, "OutputCenterlineModel")
+    self.UpdateInputNodeWithThisOutputNode(self._parameterNode.outputCenterlineCurve, "OutputCenterlineCurve")
+    self._parameterNode.inputCurveNode.EndModify(wasModified)
 
-  def UpdateInputNodeWithParameters(self):
-    if not self.logic.inputCurveNode:
+  def UpdateInputNodeWithParameters(self) -> None:
+    if not self._parameterNode.inputCurveNode:
         return
-    wasModified = self.logic.inputCurveNode.StartModify()
+    wasModified = self._parameterNode.inputCurveNode.StartModify()
     
-    sliceNode = self.logic.inputSliceNode
+    sliceNode = self._parameterNode.inputSliceNode
     sliceWidget = slicer.app.layoutManager().sliceWidget(sliceNode.GetName())
     volumeNode = sliceWidget.sliceLogic().GetBackgroundLayer().GetVolumeNode()
-    self.logic.inputCurveNode.SetNodeReferenceID("InputVolumeNode", volumeNode.GetID())
+    self._parameterNode.inputCurveNode.SetNodeReferenceID("InputVolumeNode", volumeNode.GetID())
     
-    shapeNode = self.ui.inputShapeSelector.currentNode()
+    shapeNode = self.logic.getShapeNode()
     shapeNodeID = shapeNode.GetID() if shapeNode is not None else ""
-    self.logic.inputCurveNode.SetNodeReferenceID("InputShapeNode", shapeNodeID)
+    self._parameterNode.inputCurveNode.SetNodeReferenceID("InputShapeNode", shapeNodeID)
     
-    self.logic.inputCurveNode.SetAttribute("TubeDiameter", str(self.ui.tubeDiameterSpinBox.value))
-    self.logic.inputCurveNode.SetAttribute("InputIntensityTolerance", str(self.ui.intensityToleranceSpinBox.value))
-    self.logic.inputCurveNode.SetAttribute("NeighbourhoodSize", str(self.ui.neighbourhoodSizeDoubleSpinBox.value))
-    self.logic.inputCurveNode.EndModify(wasModified)
+    self._parameterNode.inputCurveNode.SetAttribute("TubeDiameter", str(self._parameterNode.tubeDiameter))
+    self._parameterNode.inputCurveNode.SetAttribute("InputIntensityTolerance", str(self._parameterNode.intensityTolerance))
+    self._parameterNode.inputCurveNode.SetAttribute("NeighbourhoodSize", str(self._parameterNode.neighbourhoodSize))
+    self._parameterNode.inputCurveNode.EndModify(wasModified)
 
   # Restore parameters from input curve
-  def updateGUIParametersFromInputNode(self):
-    if not self.logic.inputCurveNode:
+  def updateGUIParametersFromInputNode(self) -> None:
+    if not self._parameterNode.inputCurveNode:
         return
-    tubeDiameter = self.logic.inputCurveNode.GetAttribute("TubeDiameter")
+    tubeDiameter = self._parameterNode.inputCurveNode.GetAttribute("TubeDiameter")
     if tubeDiameter:
         self.ui.tubeDiameterSpinBox.value = float(tubeDiameter)
-    intensityTolerance = self.logic.inputCurveNode.GetAttribute("InputIntensityTolerance")
+    intensityTolerance = self._parameterNode.inputCurveNode.GetAttribute("InputIntensityTolerance")
     if intensityTolerance:
         self.ui.intensityToleranceSpinBox.value = int(intensityTolerance)
-    neighbourhoodSize = self.logic.inputCurveNode.GetAttribute("NeighbourhoodSize")
+    neighbourhoodSize = self._parameterNode.inputCurveNode.GetAttribute("NeighbourhoodSize")
     if neighbourhoodSize:
         self.ui.neighbourhoodSizeDoubleSpinBox.value = float(neighbourhoodSize)
-    shapeNode = self.logic.inputCurveNode.GetNodeReference("InputShapeNode")
+    shapeNode = self._parameterNode.inputCurveNode.GetNodeReference("InputShapeNode")
     self.ui.inputShapeSelector.setCurrentNode(shapeNode)
 
   # Restore output nodes in logic
-  def UpdateLogicWithOutputNodes(self):
-    if not self.logic.inputCurveNode:
+  def UpdateParameterNodeWithOutputNodes(self) -> None:
+    if not self._parameterNode.inputCurveNode:
         return
-    self.logic.outputFiducialNode = self.logic.inputCurveNode.GetNodeReference("OutputFiducialNode")
+    self._parameterNode.outputFiducialNode = self._parameterNode.inputCurveNode.GetNodeReference("OutputFiducialNode")
     # Here we use a segmentation specified in UI, not the one referenced in the input fiducial.
-    self.logic.outputSegmentation = self.ui.outputSegmentationSelector.currentNode()
-    self.logic.outputCenterlineModel = self.logic.inputCurveNode.GetNodeReference("OutputCenterlineModel")
-    self.logic.outputCenterlineCurve = self.logic.inputCurveNode.GetNodeReference("OutputCenterlineCurve")
+    self._parameterNode.outputSegmentation = self.ui.outputSegmentationSelector.currentNode()
+    self._parameterNode.outputCenterlineModel = self._parameterNode.inputCurveNode.GetNodeReference("OutputCenterlineModel")
+    self._parameterNode.outputCenterlineCurve = self._parameterNode.inputCurveNode.GetNodeReference("OutputCenterlineCurve")
 
-  def onApplyButton(self):
+  def onApplyButton(self) -> None:
     """
     Run processing when user clicks "Apply" button.
     """
     try:
-        if self.logic.inputCurveNode is None:
+        if self._parameterNode.inputCurveNode is None:
             self.inform("No input curve node specified.")
             return
-        if self.logic.inputCurveNode.GetNumberOfControlPoints() < 3:
+        if self._parameterNode.inputCurveNode.GetNumberOfControlPoints() < 3:
             self.inform("Input curve node must have at least 3 control points.")
             return
-        if self.logic.inputSliceNode is None:
+        if self._parameterNode.inputSliceNode is None:
             self.inform("No input slice node specified.")
             return
         # Ensure there's a background volume node.
-        sliceNode = self.logic.inputSliceNode
+        sliceNode = self._parameterNode.inputSliceNode
         sliceWidget = slicer.app.layoutManager().sliceWidget(sliceNode.GetName())
         volumeNode = sliceWidget.sliceLogic().GetBackgroundLayer().GetVolumeNode()
         if volumeNode is None:
             self.inform("No volume node selected in input slice node.")
             return
         # Restore logic output objects with referenced ones.
-        self.UpdateLogicWithOutputNodes()
+        self.UpdateParameterNodeWithOutputNodes()
         # Compute output
         self.logic.process()
         # Update parameter node with references to new output nodes.
@@ -438,7 +392,7 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
         # Update input node with input parameters.
         self.UpdateInputNodeWithParameters()
         # Update segmentation selector if it was none
-        self.ui.outputSegmentationSelector.setCurrentNode(self.logic.outputSegmentation)
+        self.ui.outputSegmentationSelector.setCurrentNode(self._parameterNode.outputSegmentation)
 
     except Exception as e:
       slicer.util.errorDisplay("Failed to compute results: "+str(e))
@@ -446,16 +400,16 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
       traceback.print_exc()
 
   # Handy during development
-  def removeOutputNodes(self):
-    inputCurveNode = self.ui.inputCurveSelector.currentNode()
+  def removeOutputNodes(self) -> None:
+    inputCurveNode = self._parameterNode.inputCurveNode
     if not inputCurveNode:
         return
     slicer.mrmlScene.RemoveNode(inputCurveNode.GetNodeReference("OutputFiducialNode"))
     slicer.mrmlScene.RemoveNode(inputCurveNode.GetNodeReference("OutputCenterlineModel"))
     slicer.mrmlScene.RemoveNode(inputCurveNode.GetNodeReference("OutputCenterlineCurve"))
-    self.logic.outputCurveNode = None
-    self.logic.outputCenterlineModel = None
-    self.logic.outputCenterlineCurve = None
+    self._parameterNode.outputFiducialNode = None
+    self._parameterNode.outputCenterlineModel = None
+    self._parameterNode.outputCenterlineCurve = None
     
     # Remove segment, ID is controlled.
     segmentation = inputCurveNode.GetNodeReference("OutputSegmentation")
@@ -479,80 +433,37 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
   https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
-  def __init__(self):
+  def __init__(self) -> None:
     """
     Called when the logic class is instantiated. Can be used for initializing member variables.
     """
     ScriptedLoadableModuleLogic.__init__(self)
     self.initMemberVariables()
-    
-  def initMemberVariables(self):
-    self.inputCurveNode = None
-    self.inputShapeNode = None
-    self.inputSliceNode = None
-    self.tubeDiameter = 8.0
-    self.intensityTolerance = 100
-    self.neighbourhoodSize = 2.0
-    self.extractCenterlines = False
-    self.outputFiducialNode = None # 'Extract centerline' endpoints
-    self.outputSegmentation = None
-    self.outputCenterlineModel = None
-    self.outputCenterlineCurve = None
-    self.segmentEditorWidgets = None
-    self.extractCenterlineWidgets = None
-
-  def setInputCurveNode(self, node):
-    if self.inputCurveNode == node:
-        return
-    self.inputCurveNode = node
   
-  def setInputShapeNode(self, node):
-    if self.inputShapeNode == node:
-        return
-    self.inputShapeNode = node
+  def getParameterNode(self):
+    return self._parameterNode
     
-  def setInputSliceNode(self, node):
-    if self.inputSliceNode == node:
-        return
-    self.inputSliceNode = node
+  def initMemberVariables(self) -> None:
+    self._parameterNode = GuidedArterySegmentationParameterNode(super().getParameterNode())
+    self._shapeNode = None
+    self._segmentEditorWidgets = None
+    self._extractCenterlineWidgets = None
 
-  def setTubeDiameter(self, value):
-    self.tubeDiameter = value
+  def setShapeNode(self, shapeNode) -> None:
+    if shapeNode == self._shapeNode:
+      return
+    self._shapeNode = shapeNode
     
-  def setIntensityTolerance(self, value):
-    self.intensityTolerance = value
-
-  def setNeighbourhoodSize(self, value):
-    self.neighbourhoodSize = value
-
-  def setExtractCenterlines(self, value):
-    self.extractCenterlines = value
-
-  def setDefaultParameters(self, parameterNode):
-    """
-    Initialize parameter node with default settings.
-    """
-    if not parameterNode.GetParameter("TubeDiameter"):
-      parameterNode.SetParameter("TubeDiameter", "8.0")
-    if not parameterNode.GetParameter("IntensityTolerance"):
-      parameterNode.SetParameter("IntensityTolerance", "100")
-    if not parameterNode.GetParameter("NeighbourhoodSize"):
-      parameterNode.SetParameter("NeighbourhoodSize", "2.0")
-      """
-    Though we want to extract centerlines, we default this flag to False.
-    Check that an accurate model is generated first.
-    Else, it can be very lengthy and disappointing if there is too much leakage. Also, Slicer may crash during centerline extraction.
-    """
-    if not parameterNode.GetParameter("ExtractCenterlines"):
-      parameterNode.SetParameter("ExtractCenterlines", "False")
-
-  def showStatusMessage(self, messages):
+  def getShapeNode(self):
+    return self._shapeNode
+    
+  def showStatusMessage(self, messages) -> None:
     separator = " "
     msg = separator.join(messages)
     slicer.util.showStatusMessage(msg, 3000)
     slicer.app.processEvents()
 
-  def process(self):
+  def process(self) -> None:
     import time
     startTime = time.time()
     logging.info('Processing started')
@@ -564,23 +475,23 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     Use a dedicated class to store widget references once only.
     Not reasonable to dig through the UI on every run.
     """
-    if not self.segmentEditorWidgets:
-        self.segmentEditorWidgets = SegmentEditorWidgets()
-        self.segmentEditorWidgets.findWidgets()
+    if not self._segmentEditorWidgets:
+        self._segmentEditorWidgets = SegmentEditorWidgets()
+        self._segmentEditorWidgets.findWidgets()
 
     # Create a new segmentation if none is specified.
-    if not self.outputSegmentation:
+    if not self._parameterNode.outputSegmentation:
         segmentation=slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
-        self.outputSegmentation = segmentation
+        self._parameterNode.outputSegmentation = segmentation
     else:
         # Prefer a local reference for readability
-        segmentation = self.outputSegmentation
+        segmentation = self._parameterNode.outputSegmentation
 
     # Local direct reference to slicer.modules.SegmentEditorWidget.editor
-    seWidgetEditor=self.segmentEditorWidgets.widgetEditor
+    seWidgetEditor=self._segmentEditorWidgets.widgetEditor
 
     # Get volume node
-    sliceWidget = slicer.app.layoutManager().sliceWidget(self.inputSliceNode.GetName())
+    sliceWidget = slicer.app.layoutManager().sliceWidget(self._parameterNode.inputSliceNode.GetName())
     volumeNode = sliceWidget.sliceLogic().GetBackgroundLayer().GetVolumeNode()
     
     # Set segment editor controls
@@ -598,23 +509,23 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     mainWindow.moduleSelector().selectModule('SegmentEditor')
     
     # Show the input curve. Colour of control points change on selection, helps to wait.
-    self.inputCurveNode.SetDisplayVisibility(True)
+    self._parameterNode.inputCurveNode.SetDisplayVisibility(True)
     # Reset segment editor masking widgets. Values set by previous work must not interfere here.
-    self.segmentEditorWidgets.setMaskingOptionsToAllowOverlap()
+    self._segmentEditorWidgets.setMaskingOptionsToAllowOverlap()
     
-    if self.inputShapeNode is None:
+    if self._shapeNode is None:
       #---------------------- Draw tube with VTK---------------------
       # https://discourse.slicer.org/t/converting-markupscurve-to-markupsfiducial/20246/3
       tube = vtk.vtkTubeFilter()
-      tube.SetInputData(self.inputCurveNode.GetCurveWorld())
-      tube.SetRadius(self.tubeDiameter / 2)
+      tube.SetInputData(self._parameterNode.inputCurveNode.GetCurveWorld())
+      tube.SetRadius(self._parameterNode.tubeDiameter / 2)
       tube.SetNumberOfSides(30)
       tube.CappingOn()
       tube.Update()
       segmentation.AddSegmentFromClosedSurfaceRepresentation(tube.GetOutput(), "TubeMask")
     else:
       #---------------------- Draw tube from Shape node ---------------------
-      segmentation.AddSegmentFromClosedSurfaceRepresentation(self.inputShapeNode.GetCappedTubeWorld(), "TubeMask")
+      segmentation.AddSegmentFromClosedSurfaceRepresentation(self._shapeNode.GetCappedTubeWorld(), "TubeMask")
     # Select it so that Split Volume can work on this specific segment only.
     seWidgetEditor.setCurrentSegmentID("TubeMask")
     
@@ -663,7 +574,7 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     It will be the same in all segmentations.
     We can reach it precisely.
     """
-    segmentID = "Segment_" + self.inputCurveNode.GetID()
+    segmentID = "Segment_" + self._parameterNode.inputCurveNode.GetID()
     segment = segmentation.GetSegmentation().GetSegment(segmentID)
     if segment:
         segmentColor = segment.GetColor()
@@ -673,7 +584,7 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     object = segmentation.GetSegmentation().AddEmptySegment(segmentID)
     segment = segmentation.GetSegmentation().GetSegment(object)
     # Visually identify the segment by the input fiducial name
-    segmentName = "Segment_" + self.inputCurveNode.GetName()
+    segmentName = "Segment_" + self._parameterNode.inputCurveNode.GetName()
     segment.SetName(segmentName)
     if len(segmentColor):
         segment.SetColor(segmentColor)
@@ -684,15 +595,15 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     # Set parameters
     seWidgetEditor.setActiveEffectByName("Flood filling")
     ffEffect = seWidgetEditor.activeEffect()
-    ffEffect.setParameter("IntensityTolerance", self.intensityTolerance)
-    ffEffect.setParameter("NeighborhoodSizeMm", self.neighbourhoodSize)
+    ffEffect.setParameter("IntensityTolerance", self._parameterNode.intensityTolerance)
+    ffEffect.setParameter("NeighborhoodSizeMm", self._parameterNode.neighbourhoodSize)
     # +++ If an alien ROI is set, segmentation may fail and take an infinite time.
     ffEffect.parameterSetNode().SetNodeReferenceID("FloodFilling.ROI", None)
     ffEffect.updateGUIFromMRML()
 
     # Get input curve control points
     curveControlPoints = vtk.vtkPoints()
-    self.inputCurveNode.GetControlPointPositionsWorld(curveControlPoints)
+    self._parameterNode.inputCurveNode.GetControlPointPositionsWorld(curveControlPoints)
     numberOfCurveControlPoints = curveControlPoints.GetNumberOfPoints()
 
     # Apply flood filling at curve control points. Ignore first and last point as the resulting segment would be a big lump. The voxels of split volume at -1000 would be included in the segment.
@@ -728,7 +639,7 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
         if shNode.GetItemLevel(shSplitVolumeParentId) == "Folder":
             shNode.RemoveItem(shSplitVolumeParentId)
     
-    if not self.extractCenterlines:
+    if not self._parameterNode.extractCenterlines:
         stopTime = time.time()
         message = f'Processing completed in {stopTime-startTime:.2f} seconds'
         logging.info(message)
@@ -739,57 +650,57 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     slicer.util.showStatusMessage("Extract centerline setup")
     slicer.app.processEvents()
     mainWindow.moduleSelector().selectModule('ExtractCenterline')
-    if not self.extractCenterlineWidgets:
-        self.extractCenterlineWidgets = ExtractCenterlineWidgets()
-        self.extractCenterlineWidgets.findWidgets()
+    if not self._extractCenterlineWidgets:
+        self._extractCenterlineWidgets = ExtractCenterlineWidgets()
+        self._extractCenterlineWidgets.findWidgets()
     
-    inputSurfaceComboBox = self.extractCenterlineWidgets.inputSurfaceComboBox
-    inputSegmentSelectorWidget = self.extractCenterlineWidgets.inputSegmentSelectorWidget
-    endPointsMarkupsSelector = self.extractCenterlineWidgets.endPointsMarkupsSelector
-    outputCenterlineModelSelector = self.extractCenterlineWidgets.outputCenterlineModelSelector
-    outputCenterlineCurveSelector = self.extractCenterlineWidgets.outputCenterlineCurveSelector
-    preprocessInputSurfaceModelCheckBox = self.extractCenterlineWidgets.preprocessInputSurfaceModelCheckBox
-    applyButton = self.extractCenterlineWidgets.applyButton
+    inputSurfaceComboBox = self._extractCenterlineWidgets.inputSurfaceComboBox
+    inputSegmentSelectorWidget = self._extractCenterlineWidgets.inputSegmentSelectorWidget
+    endPointsMarkupsSelector = self._extractCenterlineWidgets.endPointsMarkupsSelector
+    outputCenterlineModelSelector = self._extractCenterlineWidgets.outputCenterlineModelSelector
+    outputCenterlineCurveSelector = self._extractCenterlineWidgets.outputCenterlineCurveSelector
+    preprocessInputSurfaceModelCheckBox = self._extractCenterlineWidgets.preprocessInputSurfaceModelCheckBox
+    applyButton = self._extractCenterlineWidgets.applyButton
     
     # Set input segmentation
     inputSurfaceComboBox.setCurrentNode(segmentation)
     inputSegmentSelectorWidget.setCurrentSegmentID(segmentID)
     # Create 2 fiducial endpoints, at start and end of input curve. We call it output because it is not user input.
-    outputFiducialNode = self.outputFiducialNode
+    outputFiducialNode = self._parameterNode.outputFiducialNode
     if not outputFiducialNode:
         outputFiducialNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
         # Visually identify the segment by the input fiducial name
-        outputFiducialNode.SetName("Endpoints_" + self.inputCurveNode.GetName())
-        firstInputCurveControlPoint = self.inputCurveNode.GetNthControlPointPositionVector(0)
+        outputFiducialNode.SetName("Endpoints_" + self._parameterNode.inputCurveNode.GetName())
+        firstInputCurveControlPoint = self._parameterNode.inputCurveNode.GetNthControlPointPositionVector(0)
         outputFiducialNode.AddControlPointWorld(firstInputCurveControlPoint)
         endPointsMarkupsSelector.setCurrentNode(outputFiducialNode)
-        lastInputCurveControlPoint = self.inputCurveNode.GetNthControlPointPositionVector(curveControlPoints.GetNumberOfPoints() - 1)
+        lastInputCurveControlPoint = self._parameterNode.inputCurveNode.GetNthControlPointPositionVector(curveControlPoints.GetNumberOfPoints() - 1)
         outputFiducialNode.AddControlPointWorld(lastInputCurveControlPoint)
         endPointsMarkupsSelector.setCurrentNode(outputFiducialNode)
-        self.outputFiducialNode = outputFiducialNode
+        self._parameterNode.outputFiducialNode = outputFiducialNode
     # Account for rename. Control points are not remaned though.
-    outputFiducialNode.SetName("Endpoints_" + self.inputCurveNode.GetName())
+    outputFiducialNode.SetName("Endpoints_" + self._parameterNode.inputCurveNode.GetName())
     
     # Output centerline model. A single node throughout.
-    centerlineModel = self.outputCenterlineModel
+    centerlineModel = self._parameterNode.outputCenterlineModel
     if not centerlineModel:
         centerlineModel = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode")
         # Visually identify the segment by the input fiducial name
-        centerlineModel.SetName("Centerline_model_" + self.inputCurveNode.GetName())
-        self.outputCenterlineModel = centerlineModel
+        centerlineModel.SetName("Centerline_model_" + self._parameterNode.inputCurveNode.GetName())
+        self._parameterNode.outputCenterlineModel = centerlineModel
     # Account for rename
-    centerlineModel.SetName("Centerline_model_" + self.inputCurveNode.GetName())
+    centerlineModel.SetName("Centerline_model_" + self._parameterNode.inputCurveNode.GetName())
     outputCenterlineModelSelector.setCurrentNode(centerlineModel)
     
     # Output centerline curve. A single node throughout.
-    centerlineCurve = self.outputCenterlineCurve
+    centerlineCurve = self._parameterNode.outputCenterlineCurve
     if not centerlineCurve:
         centerlineCurve = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsCurveNode")
         # Visually identify the segment by the input fiducial name
-        centerlineCurve.SetName("Centerline_curve_" + self.inputCurveNode.GetName())
-        self.outputCenterlineCurve = centerlineCurve
+        centerlineCurve.SetName("Centerline_curve_" + self._parameterNode.inputCurveNode.GetName())
+        self._parameterNode.outputCenterlineCurve = centerlineCurve
     # Account for rename
-    centerlineCurve.SetName("Centerline_curve_" + self.inputCurveNode.GetName())
+    centerlineCurve.SetName("Centerline_curve_" + self._parameterNode.inputCurveNode.GetName())
     
     outputCenterlineCurveSelector.setCurrentNode(centerlineCurve)
     """
@@ -799,9 +710,9 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     # Apply
     applyButton.click()
     # Hide the input curve to show the centerlines
-    self.inputCurveNode.SetDisplayVisibility(False)
+    self._parameterNode.inputCurveNode.SetDisplayVisibility(False)
     # Close network pane; we don't use this here.
-    self.extractCenterlineWidgets.outputNetworkGroupBox.collapsed = True
+    self._extractCenterlineWidgets.outputNetworkGroupBox.collapsed = True
 
     stopTime = time.time()
     message = f'Processing completed in {stopTime-startTime:.2f} seconds'
@@ -819,18 +730,18 @@ class GuidedArterySegmentationTest(ScriptedLoadableModuleTest):
   https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
   """
 
-  def setUp(self):
+  def setUp(self) -> None:
     """ Do whatever is needed to reset the state - typically a scene clear will be enough.
     """
     slicer.mrmlScene.Clear()
 
-  def runTest(self):
+  def runTest(self) -> None:
     """Run as few or as many tests as needed here.
     """
     self.setUp()
     self.test_GuidedArterySegmentation1()
 
-  def test_GuidedArterySegmentation1(self):
+  def test_GuidedArterySegmentation1(self) -> None:
     self.delayDisplay("Starting the test")
 
     self.delayDisplay('Test passed')
@@ -842,7 +753,7 @@ Widgets can be removed, or their names may change.
 That's true for library interfaces also.
 """
 class SegmentEditorWidgets(ScriptedLoadableModule):
-    def __init__(self):
+    def __init__(self) -> None:
         self.widgetEditor = None
         self.segmentationNodeComboBox = None
         self.sourceVolumeNodeComboBox = None
@@ -856,7 +767,7 @@ class SegmentEditorWidgets(ScriptedLoadableModule):
         self.overwriteModeComboBox = None
     
     # Find widgets we are using only
-    def findWidgets(self):
+    def findWidgets(self) -> None:
         # Create slicer.modules.SegmentEditorWidget
         slicer.modules.segmenteditor.widgetRepresentation()
         self.widgetEditor = slicer.modules.SegmentEditorWidget.editor
@@ -880,13 +791,13 @@ class SegmentEditorWidgets(ScriptedLoadableModule):
     findWidgets() must have been called first.
     Must be called when the first used effect is activated.
     """
-    def setMaskingOptionsToAllowOverlap(self):
+    def setMaskingOptionsToAllowOverlap(self) -> None:
         self.widgetEditor.mrmlSegmentEditorNode().SetMaskMode(slicer.vtkMRMLSegmentationNode.EditAllowedEverywhere)
         self.widgetEditor.mrmlSegmentEditorNode().SourceVolumeIntensityMaskOff()
         self.widgetEditor.mrmlSegmentEditorNode().SetOverwriteMode(self.widgetEditor.mrmlSegmentEditorNode().OverwriteNone)
 
 class ExtractCenterlineWidgets(ScriptedLoadableModule):
-    def __init__(self):
+    def __init__(self) -> None:
         self.mainContainer = None
         self.inputCollapsibleButton = None
         self.outputCollapsibleButton = None
@@ -901,7 +812,7 @@ class ExtractCenterlineWidgets(ScriptedLoadableModule):
         self.outputCenterlineCurveSelector = None
         self.preprocessInputSurfaceModelCheckBox = None
     
-    def findWidgets(self):
+    def findWidgets(self) -> None:
         ecWidgetRepresentation = slicer.modules.extractcenterline.widgetRepresentation()
         
         # Containers
@@ -925,3 +836,32 @@ class ExtractCenterlineWidgets(ScriptedLoadableModule):
         # Advanced widgets
         self.preprocessInputSurfaceModelCheckBox = self.advancedCollapsibleButton.findChild(qt.QCheckBox, "preprocessInputSurfaceModelCheckBox")
 
+
+"""
+1. Traceback (most recent call last):
+  File "/<somewhere>/Slicer/slicer.org/Extensions-32681/SlicerVMTK/lib/Slicer-5.7/qt-scripted-modules/GuidedArterySegmentation.py", line 251, in enter
+    self.initializeParameterNode()
+  File "/<somewhere>/Slicer/slicer.org/Extensions-32681/SlicerVMTK/lib/Slicer-5.7/qt-scripted-modules/GuidedArterySegmentation.py", line 285, in initializeParameterNode
+    self.setParameterNode(self.logic.getParameterNode())
+  File "/<somewhere>/Slicer/slicer.org/Extensions-32681/SlicerVMTK/lib/Slicer-5.7/qt-scripted-modules/GuidedArterySegmentation.py", line 299, in setParameterNode
+    self._parameterNodeGuiTag = self._parameterNode.connectGui(self.ui)
+  File "/<somewhere>/Slicer/bin/Python/slicer/parameterNodeWrapper/wrapper.py", line 253, in _connectGui
+    _connectParametersToGui(self, paramNameToWidget)
+  File "/<somewhere>/Slicer/bin/Python/slicer/parameterNodeWrapper/wrapper.py", line 197, in _connectParametersToGui
+    _checkParamName(self, paramName)
+  File "/<somewhere>/Slicer/bin/Python/slicer/parameterNodeWrapper/wrapper.py", line 156, in _checkParamName
+    raise ValueError(f"Cannot find a param with the given name: {topname}"
+ValueError: Cannot find a param with the given name: inputShapeNode
+  Found parameters [
+    inputCurveNode,
+    inputSliceNode,
+    tubeDiameter,
+    intensityTolerance,
+    neighbourhoodSize,
+    extractCenterlines,
+    outputSegmentation,
+    outputFiducialNode,
+    outputCenterlineModel,
+    outputCenterlineCurve,
+  ]
+"""

--- a/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
+++ b/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
@@ -66,6 +66,9 @@ The control points are assumed to be on the contrasted lumen.</string>
         <property name="renameEnabled">
          <bool>true</bool>
         </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>inputCurveNode</string>
+        </property>
        </widget>
       </item>
       <item row="7" column="0">
@@ -99,6 +102,9 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
         </property>
         <property name="value">
          <double>8.000000000000000</double>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>tubeDiameter</string>
         </property>
        </widget>
       </item>
@@ -134,6 +140,9 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
         <property name="renameEnabled">
          <bool>true</bool>
         </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>outputSegmentation</string>
+        </property>
        </widget>
       </item>
       <item row="2" column="1">
@@ -162,6 +171,9 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
           </property>
           <property name="selectNodeUponCreation">
            <bool>false</bool>
+          </property>
+          <property name="SlicerParameterName" stdset="0">
+           <string>inputSliceNode</string>
           </property>
          </widget>
         </item>
@@ -328,6 +340,9 @@ If specified, the regular tube diameter above is ignored.</string>
          <property name="value">
           <number>100</number>
          </property>
+         <property name="SlicerParameterName" stdset="0">
+          <string>intensityTolerance</string>
+         </property>
         </widget>
        </item>
        <item row="1" column="0">
@@ -361,6 +376,9 @@ If specified, the regular tube diameter above is ignored.</string>
          <property name="value">
           <double>2.000000000000000</double>
          </property>
+         <property name="SlicerParameterName" stdset="0">
+          <string>neighbourhoodSize</string>
+         </property>
         </widget>
        </item>
       </layout>
@@ -371,6 +389,9 @@ If specified, the regular tube diameter above is ignored.</string>
     <widget class="QCheckBox" name="extractCenterlinesCheckBox">
      <property name="text">
       <string>Extract centerlines</string>
+     </property>
+     <property name="SlicerParameterName" stdset="0">
+      <string>extractCenterlines</string>
      </property>
     </widget>
    </item>

--- a/QuickArterySegmentation/Resources/UI/QuickArterySegmentation.ui
+++ b/QuickArterySegmentation/Resources/UI/QuickArterySegmentation.ui
@@ -53,6 +53,9 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
         <property name="renameEnabled">
          <bool>true</bool>
         </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>inputFiducialNode</string>
+        </property>
        </widget>
       </item>
       <item row="4" column="1">
@@ -72,6 +75,9 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
           </property>
           <property name="noneEnabled">
            <bool>true</bool>
+          </property>
+          <property name="SlicerParameterName" stdset="0">
+           <string>inputROINode</string>
           </property>
          </widget>
         </item>
@@ -142,6 +148,9 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
         <property name="selectNodeUponCreation">
          <bool>true</bool>
         </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>outputSegmentationNode</string>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -170,6 +179,9 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
           </property>
           <property name="selectNodeUponCreation">
            <bool>false</bool>
+          </property>
+          <property name="SlicerParameterName" stdset="0">
+           <string>inputSliceNode</string>
           </property>
          </widget>
         </item>
@@ -252,6 +264,9 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <property name="value">
           <number>100</number>
          </property>
+         <property name="SlicerParameterName" stdset="0">
+          <string>inputIntensityTolerance</string>
+         </property>
         </widget>
        </item>
        <item row="1" column="0">
@@ -285,6 +300,9 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <property name="value">
           <double>2.000000000000000</double>
          </property>
+         <property name="SlicerParameterName" stdset="0">
+          <string>inputNeighbourhoodSize</string>
+         </property>
         </widget>
        </item>
       </layout>
@@ -309,6 +327,9 @@ It is recommended to generate centerlines on accurate segmentations.</string>
      </property>
      <property name="tristate">
       <bool>false</bool>
+     </property>
+     <property name="SlicerParameterName" stdset="0">
+      <string>optionExtractCenterlines</string>
      </property>
     </widget>
    </item>

--- a/StenosisMeasurement1D/Resources/UI/StenosisMeasurement1D.ui
+++ b/StenosisMeasurement1D/Resources/UI/StenosisMeasurement1D.ui
@@ -52,6 +52,9 @@
         <property name="renameEnabled">
          <bool>true</bool>
         </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>inputCurveNode</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/StenosisMeasurement2D/Resources/UI/StenosisMeasurement2D.ui
+++ b/StenosisMeasurement2D/Resources/UI/StenosisMeasurement2D.ui
@@ -59,6 +59,9 @@
             <property name="selectNodeUponCreation">
              <bool>false</bool>
             </property>
+            <property name="SlicerParameterName" stdset="0">
+             <string>inputSliceNode</string>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -98,6 +101,9 @@ Clicking at a control point allows to track the slice orientation in the selecte
             <property name="selectNodeUponCreation">
              <bool>false</bool>
             </property>
+            <property name="SlicerParameterName" stdset="0">
+             <string>inputFiducialNode</string>
+            </property>
            </widget>
           </item>
           <item row="2" column="0">
@@ -130,7 +136,7 @@ Clicking at a control point allows to track the slice orientation in the selecte
       <item>
        <widget class="ctkCollapsibleButton" name="optionsCollapsibleButton">
         <property name="toolTip">
-         <string>Right click for more.</string>
+         <string/>
         </property>
         <property name="text">
          <string>Options</string>
@@ -153,7 +159,10 @@ Clicking at a control point allows to track the slice orientation in the selecte
               <string>Apply to all segments</string>
              </property>
              <property name="checked">
-              <bool>true</bool>
+              <bool>false</bool>
+             </property>
+             <property name="SlicerParameterName" stdset="0">
+              <string>applyToAllSegments</string>
              </property>
             </widget>
            </item>
@@ -167,6 +176,9 @@ Clicking at a control point allows to track the slice orientation in the selecte
              </property>
              <property name="checked">
               <bool>true</bool>
+             </property>
+             <property name="SlicerParameterName" stdset="0">
+              <string>limitToClosestIslands</string>
              </property>
             </widget>
            </item>
@@ -203,6 +215,9 @@ The result is influenced by :
                   <property name="checked">
                    <bool>true</bool>
                   </property>
+                  <property name="SlicerParameterName" stdset="0">
+                   <string>createOutputModel</string>
+                  </property>
                  </widget>
                 </item>
                 <item>
@@ -214,6 +229,9 @@ The slice orientation in the selected view will be set to the known previous one
                   </property>
                   <property name="text">
                    <string>Reset control point orientation</string>
+                  </property>
+                  <property name="SlicerParameterName" stdset="0">
+                   <string>resetControlPointOrientation</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
Hi @sjh26, @pieper, @lassoan, 

This maintenance PR implements the new parameter node wrapper where it is possible. It is intended to be merged in 'Rebase and merge' mode.

The commits follow the same pattern as discussed [here](https://discourse.slicer.org/t/how-to-handle-the-new-parameter-node-wrapper/33957). Basically, reference the parameter node in the logic in addition to the widget class, and store output objects as well as members of the parameter node class.

Two minor changes are included:
- fix the minimum number of points required by a curve in 'GuidedArterySegmentation',
- rename a widget in 'BranchClipper' removing the 'FooBar' template string.

I request the approval of at least one Slicer developer before merging it.

Thanks and regards.
