### PR TITLE
Make most modules translatable

### DIFF
--- a/ArterialCalcificationPreProcessor/ArterialCalcificationPreProcessor.py
+++ b/ArterialCalcificationPreProcessor/ArterialCalcificationPreProcessor.py
@@ -6,6 +6,8 @@ import vtk
 import  qt
 
 import slicer
+from slicer.i18n import tr as _
+from slicer.i18n import translate
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 from slicer.parameterNodeWrapper import (
@@ -32,15 +34,15 @@ class ArterialCalcificationPreProcessor(ScriptedLoadableModule):
         self.parent.dependencies = [] 
         self.parent.contributors = ["Saleem Edah-Tally [Surgeon] [Hobbyist developer]"]  # TODO: replace with "Firstname Lastname (Organization)"
         # TODO: update with short description of the module and a link to online module documentation
-        self.parent.helpText = """
+        self.parent.helpText = _("""
 Segment calcifications around an arterial lumen within a margin.
 See more information in <a href="href="https://github.com/vmtk/SlicerExtension-VMTK/">module documentation</a>.
-"""
+""")
         # TODO: replace with organization, grant and thanks
-        self.parent.acknowledgementText = """
+        self.parent.acknowledgementText = _("""
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc., Andras Lasso, PerkLab,
 and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR013218-12S1.
-"""
+""")
 
 #
 # ArterialCalcificationPreProcessorParameterNode
@@ -102,7 +104,7 @@ class ArterialCalcificationPreProcessorWidget(ScriptedLoadableModuleWidget, VTKO
         self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
         
         self.ui.applyButton.menu().clear()
-        self._show3DAction = qt.QAction("Show 3D on success")
+        self._show3DAction = qt.QAction(_("Show 3D on success"))
         self._show3DAction.setCheckable(True)
         self.ui.applyButton.menu().addAction(self._show3DAction)
 
@@ -177,7 +179,7 @@ class ArterialCalcificationPreProcessorWidget(ScriptedLoadableModuleWidget, VTKO
         inputSegmentation = self.ui.segmentSelector.currentNode()
         optionShow3D = self._show3DAction.checked
         
-        with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
+        with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
             
             # Compute output
             self.logic.process(inputSegmentation,
@@ -214,11 +216,11 @@ class ArterialCalcificationPreProcessorLogic(ScriptedLoadableModuleLogic):
                 marginSize: float = 4.0) -> None:
 
         if not inputSegmentation or not inputVolume or not segmentID or segmentID == "":
-            raise ValueError("Input segmentation, volume or segment ID is invalid")
+            raise ValueError(_("Input segmentation, volume or segment ID is invalid"))
         
         import time
         startTime = time.time()
-        logging.info('Processing started')
+        logging.info(_("Processing started"))
         
         """
         We need the volume to get intensity values.
@@ -291,7 +293,8 @@ class ArterialCalcificationPreProcessorLogic(ScriptedLoadableModuleLogic):
         inputSegmentation.GetDisplayNode().SetSegmentOpacity3D(calcifSegmentID, 0.5)
 
         stopTime = time.time()
-        logging.info(f'Processing completed in {stopTime-startTime:.2f} seconds')
+        durationValue = '%.2f' % (stopTime-startTime)
+        logging.info(_("Processing completed in {duration} seconds").format(duration=durationValue))
 
 #
 # ArterialCalcificationPreProcessorTest
@@ -312,6 +315,6 @@ class ArterialCalcificationPreProcessorTest(ScriptedLoadableModuleTest):
 
     def test_ArterialCalcificationPreProcessor1(self):
 
-        self.delayDisplay("Starting the test")
+        self.delayDisplay(_("Starting the test"))
 
-        self.delayDisplay('Test passed')
+        self.delayDisplay(_("Test passed"))

--- a/ArterialCalcificationPreProcessor/Resources/UI/ArterialCalcificationPreProcessor.ui
+++ b/ArterialCalcificationPreProcessor/Resources/UI/ArterialCalcificationPreProcessor.ui
@@ -51,7 +51,7 @@
         <double>4.000000000000000</double>
        </property>
        <property name="SlicerParameterName" stdset="0">
-        <string>marginSize</string>
+        <string notr="true">marginSize</string>
        </property>
       </widget>
      </item>
@@ -98,7 +98,7 @@
         <string notr="true"/>
        </property>
        <property name="SlicerParameterName" stdset="0">
-        <string>inputVolume</string>
+        <string notr="true">inputVolume</string>
        </property>
       </widget>
      </item>
@@ -139,6 +139,7 @@
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/BranchClipper/Resources/UI/qSlicerBranchClipperModuleWidget.ui
+++ b/BranchClipper/Resources/UI/qSlicerBranchClipperModuleWidget.ui
@@ -36,7 +36,7 @@
          <string>Pick the input centerline model.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLModelNode</string>
          </stringlist>
         </property>
@@ -82,7 +82,7 @@ The input centerline is expected to be inside the lumen surface.</string>
            <locale language="English" country="UnitedStates"/>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLSegmentationNode</string>
            </stringlist>
           </property>

--- a/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
+++ b/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
@@ -89,7 +89,7 @@ void qSlicerBranchClipperModuleWidget::onApply()
   vtkMRMLModelNode * centerlineModel = vtkMRMLModelNode::SafeDownCast( d->inputCenterlineSelector->currentNode());
   if (centerlineModel == nullptr)
   {
-    this->showStatusMessage("No centerline selected.", 5000);
+    this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("No centerline selected."), 5000);
     return;
   }
   centerlines->DeepCopy(centerlineModel->GetPolyData());
@@ -98,13 +98,13 @@ void qSlicerBranchClipperModuleWidget::onApply()
   vtkMRMLNode * segmentationNode = d->segmentationSelector->currentNode();
   if (segmentationNode == nullptr)
   {
-    this->showStatusMessage("No segmentation selected.", 5000);
+    this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("No segmentation selected."), 5000);
     return;
   }
   if ((d->bifurcationProfilesToolButton->isChecked() == false)
     && (d->branchSegmentsToolButton->isChecked() == false))
   {
-    this->showStatusMessage("No output selected.", 5000);
+    this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("No output selected."), 5000);
     return;
   }
   // Use controlled segment IDs. We can find and delete them precisely.
@@ -118,8 +118,8 @@ void qSlicerBranchClipperModuleWidget::onApply()
     segmentation = vtkMRMLSegmentationNode::SafeDownCast(d->segmentationSelector->currentNode());
     if (segmentation->GetSegmentation() == nullptr) // Can it happen ?
     {
-      const char * msg = "Segmentation is NULL in MRML node, aborting";
-      cerr << msg << endl;
+      const QString msg = qSlicerBranchClipperModuleWidget::tr("Segmentation is NULL in MRML node, aborting");
+      cerr << msg.toStdString() << endl;
       this->showStatusMessage(msg, 5000);
       return;
     }
@@ -129,7 +129,7 @@ void qSlicerBranchClipperModuleWidget::onApply()
       segmentID = d->segmentSelector->currentSegmentID().toStdString();
       if (segmentID.empty())
       {
-        const char * msg = "No segment selected.";
+        const QString msg = qSlicerBranchClipperModuleWidget::tr("No segment selected.");
         this->showStatusMessage(msg, 5000);
         return;
       }
@@ -140,8 +140,8 @@ void qSlicerBranchClipperModuleWidget::onApply()
     }
     else
     {
-      const char * msg = "Could not create closed surface representation.";
-      cerr << msg << endl;
+      const QString msg = qSlicerBranchClipperModuleWidget::tr("Could not create closed surface representation.");
+      cerr << msg.toStdString() << endl;
       this->showStatusMessage(msg, 5000);
       return;
     }
@@ -149,8 +149,8 @@ void qSlicerBranchClipperModuleWidget::onApply()
   else
   {
     // Should not happen.
-    const char * msg = "Unknown surface node";
-    cerr << msg << endl;
+    const QString msg = qSlicerBranchClipperModuleWidget::tr("Unknown surface node");
+    cerr << msg.toStdString() << endl;
     this->showStatusMessage(msg, 5000);
     return;
   }
@@ -159,15 +159,16 @@ void qSlicerBranchClipperModuleWidget::onApply()
   
   // Debranch now. Execute() can be a long process on heavy segmentations.
   timer->StartTimer();
-  this->showStatusMessage("Debranching, please wait...");
+  this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("Debranching, please wait..."));
+
   vtkNew<vtkSlicerBranchClipperLogic> logic;
   logic->SetCenterlines(centerlines);
   logic->SetSurface(surface);
   logic->Execute();
   if (logic->GetOutput() == nullptr)
   {
-    const char * msg = "Could not create a valid surface.";
-    cerr << msg << endl;
+    const QString msg = qSlicerBranchClipperModuleWidget::tr("Could not create a valid surface.");
+    cerr << msg.toStdString() << endl;
     this->showStatusMessage(msg, 5000);
     return;
   }
@@ -186,26 +187,29 @@ void qSlicerBranchClipperModuleWidget::onApply()
     if (numberOfBranches == 0)
     {
       mrmlScene()->EndState(vtkMRMLScene::BatchProcessState);
-      const char * msg = "No branches could be retrieved; the centerline may be invalid.";
-      cerr << msg << endl;
+      const QString msg = qSlicerBranchClipperModuleWidget::tr("No branches could be retrieved; the centerline may be invalid.");
+      cerr << msg.toStdString() << endl;
       this->showStatusMessage(msg, 5000);
       return;
     }
     for (vtkIdType i = 0; i < numberOfBranches; i++)
     {
       timer->StartTimer();
-      std::string info("Processing branch ");
+      std::string info(qSlicerBranchClipperModuleWidget::tr("Processing branch ").toStdString());
       info += std::to_string(i + 1) + std::string("/") + std::to_string(numberOfBranches);
-      cout << info; // no endl
       this->showStatusMessage(info.c_str());
+      
+      std::string consoleInfo("Processing branch ");
+      consoleInfo += std::to_string(i + 1) + std::string("/") + std::to_string(numberOfBranches);
+      cout << consoleInfo; // no endl
       
       vtkNew<vtkPolyData> branchSurface;
       logic->GetBranch(i, branchSurface);
       if (branchSurface == nullptr)
       {
         cout << endl;
-        const char * msg = "Could not retrieve branch surface ";
-        cerr << msg << i << "." << endl;
+        const QString msg = qSlicerBranchClipperModuleWidget::tr("Could not retrieve branch surface ");
+        cerr << msg.toStdString() << i << "." << endl;
         this->showStatusMessage(msg, 5000);
         continue;
       }
@@ -260,8 +264,8 @@ void qSlicerBranchClipperModuleWidget::onApply()
     if (!profiledPolyDatas)
     {
       mrmlScene()->EndState(vtkMRMLScene::BatchProcessState);
-      const char * msg = "Could not get a valid collection of bifurcation profiles.";
-      cerr << msg << endl;
+      const QString msg = qSlicerBranchClipperModuleWidget::tr("Could not get a valid collection of bifurcation profiles.");
+      cerr << msg.toStdString() << endl;
       this->showStatusMessage(msg, 5000);
       return;
     }
@@ -269,8 +273,8 @@ void qSlicerBranchClipperModuleWidget::onApply()
     if (shNode == nullptr) // ?
     {
       mrmlScene()->EndState(vtkMRMLScene::BatchProcessState);
-      const char * msg = "Could not get a valid subject hierarchy node.";
-      cerr << msg << endl;
+      const QString msg = qSlicerBranchClipperModuleWidget::tr("Could not get a valid subject hierarchy node.");
+      cerr << msg.toStdString() << endl;
       this->showStatusMessage(msg, 5000);
       return;
     }
@@ -279,7 +283,7 @@ void qSlicerBranchClipperModuleWidget::onApply()
     
     // Create a child folder of the input centerline to contain all created models.
     vtkIdType shMasterCenterlineId = shNode->GetItemByDataNode(centerlineModel);
-    vtkIdType shFolderId = shNode->CreateFolderItem(shMasterCenterlineId, "Bifurcation profiles");
+    vtkIdType shFolderId = shNode->CreateFolderItem(shMasterCenterlineId, qSlicerBranchClipperModuleWidget::tr("Bifurcation profiles").toStdString());
     shNode->SetItemExpanded(shFolderId, false);
     // Seed with a constant for predictable random table and colours.
     vtkMath::RandomSeed(7);
@@ -305,7 +309,7 @@ void qSlicerBranchClipperModuleWidget::onApply()
   }
   
   mrmlScene()->EndState(vtkMRMLScene::BatchProcessState);
-  this->showStatusMessage("Finished", 5000);
+  this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("Finished"), 5000);
 }
 
 //-------------------------- From util.py -------------------------------------

--- a/CenterlineDisassembly/CenterlineDisassembly.py
+++ b/CenterlineDisassembly/CenterlineDisassembly.py
@@ -486,7 +486,8 @@ class CenterlineDisassemblyLogic(ScriptedLoadableModuleLogic):
             curveNode.SetName(curveName)
         
         stopTime = time.time()
-        logging.info(f"Processing curve creation completed in {stopTime-startTime:.2f} seconds")
+        durationValue = '%.2f' % (stopTime-startTime)
+        logging.info(_("Processing curve creation completed in {duration} seconds").format(duration=durationValue))
     
     def processCenterlineIds(self):
 
@@ -514,7 +515,8 @@ class CenterlineDisassemblyLogic(ScriptedLoadableModuleLogic):
             centerlinePolyDatas.append(appendPolyData.GetOutput())
         
         stopTime = time.time()
-        logging.info(f"Processing centerline ids completed in {stopTime-startTime:.2f} seconds")
+        durationValue = '%.2f' % (stopTime-startTime)
+        logging.info(_("Processing centerline ids completed in {duration} seconds").format(duration=durationValue))
         return centerlinePolyDatas
 
     def processGroupIds(self, bifurcations):
@@ -556,7 +558,8 @@ class CenterlineDisassemblyLogic(ScriptedLoadableModuleLogic):
                     groupIdsPolyDatas.append(unitCellPolyData)
         
         stopTime = time.time()
-        logging.info(f"Processing group ids completed in {stopTime-startTime:.2f} seconds")
+        durationValue = '%.2f' % (stopTime-startTime)
+        logging.info(_("Processing group ids completed in {duration} seconds").format(duration=durationValue))
         return groupIdsPolyDatas
 #
 # CenterlineDisassemblyTest

--- a/CenterlineDisassembly/Resources/UI/CenterlineDisassembly.ui
+++ b/CenterlineDisassembly/Resources/UI/CenterlineDisassembly.ui
@@ -156,6 +156,7 @@ Upon curve creation, the visibility of the names can be specified via the menu.<
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -2,6 +2,9 @@ import os
 import unittest
 import logging
 import vtk, qt, ctk, slicer
+from slicer.i18n import tr as _
+from slicer.i18n import translate
+
 import numpy as np
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
@@ -23,14 +26,14 @@ class CrossSectionAnalysis(ScriptedLoadableModule):
     self.parent.categories = ["Vascular Modeling Toolkit"]
     self.parent.dependencies = []
     self.parent.contributors = ["Saleem Edah-Tally (Surgeon) (Hobbyist developer)", "Andras Lasso (PerkLab)"]
-    self.parent.helpText = """
+    self.parent.helpText = _("""
 This module describes cross-sections along a VMTK centerline model, a VMTK centerline markups curve or an arbitrary markups curve. Documentation is available
     <a href="https://github.com/vmtk/SlicerExtension-VMTK/">here</a>.
-"""
-    self.parent.acknowledgementText = """
+""")
+    self.parent.acknowledgementText = _("""
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc., Andras Lasso, PerkLab,
 and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR013218-12S1.
-"""  # TODO: replace with organization, grant and thanks.
+""")  # TODO: replace with organization, grant and thanks.
 
 #
 # CrossSectionAnalysisWidget
@@ -328,7 +331,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
 
   def onApplyButton(self):
     if not self.logic.isInputCenterlineValid():
-        msg = "Input is invalid."
+        msg = _("Input is invalid.")
         slicer.util.showStatusMessage(msg, 3000)
         logging.info(msg)
         return # Just don't do anything
@@ -417,7 +420,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
       self.ui.surfaceAreaValueLabel.setText(self.logic.getUnitNodeDisplayString(surfaceArea, "area").strip())
       self.ui.surfaceAreaValueLabel.setToolTip(str(surfaceArea))
     else:
-      self.ui.surfaceAreaValueLabel.setText("N/A (input lumen surface not specified)")
+      self.ui.surfaceAreaValueLabel.setText(_("N/A (input lumen surface not specified)"))
 
     if surfaceArea > 0.0:
       derivedDiameterVariant = tableNode.GetTable().GetValueByName(int(value), CE_DIAMETER_ARRAY_NAME)
@@ -436,7 +439,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         """
         diameterPercentDifference = (diameterDifference / misDiameter) * 100
         diameterDifferenceSign = "+" if diameterPercentDifference >=0 else "-"
-        derivedDiameterStr += f" (MIS diameter {diameterDifferenceSign}"
+        derivedDiameterStr += _(" (MIS diameter {sign}").format(sign=diameterDifferenceSign)
         # Using str().strip() to remove a leading space
         derivedDiameterStr += self.logic.getUnitNodeDisplayString(abs(diameterDifference), "length").strip()
         derivedDiameterStr += f", {diameterDifferenceSign}{round(abs(diameterPercentDifference), 2)}%)"
@@ -586,13 +589,13 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
   def setInputCenterlineNode(self, centerlineNode):
     if (centerlineNode is not None) and (centerlineNode.IsTypeOf("vtkMRMLMarkupsShapeNode")):
       if centerlineNode.GetShapeName() != slicer.vtkMRMLMarkupsShapeNode.Tube :
-        self.logic.showStatusMessage(("Selected Shape node is not a Tube.",))
+        self.logic.showStatusMessage((_("Selected Shape node is not a Tube."),))
         self.ui.inputCenterlineSelector.setCurrentNode(None)
         self.logic.setInputCenterlineNode(None)
         return
     if (centerlineNode is not None) and (centerlineNode.IsTypeOf("vtkMRMLModelNode")):
       if not centerlineNode.HasPointScalarName("Radius"):
-        self.logic.showStatusMessage(("Selected model node does not have radius information.",))
+        self.logic.showStatusMessage((_("Selected model node does not have radius information."),))
         self.ui.inputCenterlineSelector.setCurrentNode(None)
         self.logic.setInputCenterlineNode(None)
         return
@@ -611,16 +614,16 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     comboBox.clear()
     
     if self.logic.isCenterlineRadiusAvailable():
-        comboBox.addItem("MIS diameter", MIS_DIAMETER)
+        comboBox.addItem(_("MIS diameter"), MIS_DIAMETER)
     if self.logic.lumenSurfaceNode:
-      comboBox.addItem("CE diameter", CE_DIAMETER)
-      comboBox.addItem("Cross-section area", CROSS_SECTION_AREA)
+      comboBox.addItem(_("CE diameter"), CE_DIAMETER)
+      comboBox.addItem(_("Cross-section area"), CROSS_SECTION_AREA)
     if self.logic.inputCenterlineNode and self.logic.inputCenterlineNode.IsTypeOf("vtkMRMLMarkupsShapeNode"):
-      comboBox.addItem("Wall diameter", WALL_CE_DIAMETER)
-      comboBox.addItem("Wall cross-section area", WALL_CROSS_SECTION_AREA)
+      comboBox.addItem(_("Wall diameter"), WALL_CE_DIAMETER)
+      comboBox.addItem(_("Wall cross-section area"), WALL_CROSS_SECTION_AREA)
       if self.logic.lumenSurfaceNode:
-        comboBox.addItem("Stenosis by diameter (CE)", DIAMETER_STENOSIS)
-        comboBox.addItem("Stenosis by surface area", SURFACE_AREA_STENOSIS)
+        comboBox.addItem(_("Stenosis by diameter (CE)"), DIAMETER_STENOSIS)
+        comboBox.addItem(_("Stenosis by surface area"), SURFACE_AREA_STENOSIS)
 
     if (comboBox.count):
       comboBox.setCurrentIndex(0)
@@ -861,17 +864,17 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
   def run(self):
     self.resetCrossSections()
     if not self.isInputCenterlineValid():
-        msg = "Input is invalid."
+        msg = _("Input is invalid.")
         slicer.util.showStatusMessage(msg, 3000)
         raise ValueError(msg)
 
-    logging.info('Processing started')
+    logging.info(_("Processing started"))
     if self.outputTableNode:
       self.emptyOutputTableNode()
       self.updateOutputTable(self.inputCenterlineNode, self.outputTableNode)
     if self.outputPlotSeriesNode:
       self.updatePlot(self.outputPlotSeriesNode, self.outputTableNode, self.inputCenterlineNode.GetName())
-    logging.info('Processing completed')
+    logging.info(_("Processing completed"))
 
   def emptyOutputTableNode(self):
     # Clears the plot also.
@@ -1010,7 +1013,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
             crossSectionCompute.SetInputCenterlinePolyData(inputCenterline.GetCurveWorld())
     if self.lumenSurfaceNode:
         crossSectionCompute.SetInputSurfaceNode(self.lumenSurfaceNode, self.currentSegmentID)
-        self.showStatusMessage(("Waiting for background jobs...", ))
+        self.showStatusMessage((_("Waiting for background jobs..."), ))
         crossSectionCompute.UpdateTable(crossSectionAreaArray, ceDiameterArray)
     
     """
@@ -1029,7 +1032,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
         wallCrossSectionCompute.SetInputCenterlinePolyData(inputCenterline.GetSplineWorld())
       else:
         wallCrossSectionCompute.SetInputCenterlinePolyData(trimmedSpline)
-      self.showStatusMessage(("Waiting for background jobs...", ))
+      self.showStatusMessage((_("Waiting for background jobs..."), ))
       wallCrossSectionCompute.UpdateTable(wallCrossSectionAreaArray, wallDiameterArray)
     
     cumArray = vtk.vtkDoubleArray()
@@ -1039,7 +1042,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
             
     for i in range(numberOfPoints):
       if (((i + 1) % 25) == 0):
-          self.showStatusMessage(("Updating table :", str(i + 1), "/", str(numberOfPoints)))
+          self.showStatusMessage((_("Updating table :"), str(i + 1), "/", str(numberOfPoints)))
       # Distance from relative origin
       distanceArray.SetValue(i, relArray.GetValue(i))
       # Radii
@@ -1077,7 +1080,8 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     outputTable.GetTable().Modified()
     
     stopTime = time.time()
-    message = f'Processing completed in {stopTime-startTime:.2f} seconds - {numberOfPoints} points'
+    durationValue = '%.2f' % (stopTime-startTime)
+    message = _("Processing completed in {duration} seconds - {countOfPoints} points").format(duration=durationValue, countOfPoints=numberOfPoints)
     logging.info(message)
     slicer.util.showStatusMessage(message, 5000)
 
@@ -1140,21 +1144,21 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
 
     lengthUnit = self.getUnitNodeUnitDisplayString(0.0, "length")
     areaUnit = self.getUnitNodeUnitDisplayString(0.0, "area")
-    self.plotChartNode.SetXAxisTitle(f"{DISTANCE_ARRAY_NAME} ( {lengthUnit})")
+    self.plotChartNode.SetXAxisTitle("{nameOfDistanceArray} ( {unitOfLength})".format(nameOfDistanceArray=DISTANCE_ARRAY_NAME, unitOfLength=lengthUnit))
     if self.outputPlotSeriesType == MIS_DIAMETER:
-        self.plotChartNode.SetYAxisTitle(f"Diameter ({lengthUnit})")
+        self.plotChartNode.SetYAxisTitle(_("Diameter ({unitOfLength})").format(unitOfLength=lengthUnit))
     if self.outputPlotSeriesType == CE_DIAMETER:
-        self.plotChartNode.SetYAxisTitle(f"Diameter ({lengthUnit})")
+        self.plotChartNode.SetYAxisTitle(_("Diameter ({unitOfLength})").format(unitOfLength=lengthUnit))
     elif self.outputPlotSeriesType == CROSS_SECTION_AREA:
-        self.plotChartNode.SetYAxisTitle(f"Area ({areaUnit})")
+        self.plotChartNode.SetYAxisTitle(_("Area ({unitOfArea})").format(unitOfArea=areaUnit))
     elif self.outputPlotSeriesType == WALL_CE_DIAMETER:
-        self.plotChartNode.SetYAxisTitle(f"Diameter ({lengthUnit})")
+        self.plotChartNode.SetYAxisTitle(_("Diameter ({unitOfLength})").format(unitOfLength=lengthUnit))
     elif self.outputPlotSeriesType == WALL_CROSS_SECTION_AREA:
-        self.plotChartNode.SetYAxisTitle(f"Area ({areaUnit})")
+        self.plotChartNode.SetYAxisTitle(_("Area ({unitOfArea})").format(unitOfArea=areaUnit))
     elif self.outputPlotSeriesType == DIAMETER_STENOSIS:
-        self.plotChartNode.SetYAxisTitle(f"Stenosis (%)")
+        self.plotChartNode.SetYAxisTitle(_("Stenosis (%)"))
     elif self.outputPlotSeriesType == SURFACE_AREA_STENOSIS:
-        self.plotChartNode.SetYAxisTitle(f"Stenosis (%)")
+        self.plotChartNode.SetYAxisTitle(_("Stenosis (%)"))
     else:
       pass
     # Make sure the plot is in the chart
@@ -1371,11 +1375,11 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     planePoints = planeCut.GetOutput().GetPoints()
     # self.lumenSurfaceNode.GetDisplayNode().GetSegmentVisibility3D(self.currentSegmentID) doesn't work as expected. Even if the segment is hidden in 3D view, it returns True.
     if planePoints is None:
-        msg = "Could not cut segment. Is it visible in 3D view?"
+        msg = _("Could not cut segment. Is it visible in 3D view?")
         slicer.util.showStatusMessage(msg, 3000)
         raise ValueError(msg)
     if planePoints.GetNumberOfPoints() < 3:
-        logging.info("Not enough points to create surface")
+        logging.info(_("Not enough points to create surface"))
         return None
 
     # Keep the closed surface around the centerline
@@ -1408,7 +1412,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     # Finally create/update the model node
     if self.crossSectionModelNode is None:
       self.crossSectionModelNode = slicer.modules.models.logic().AddModel(crossSectionPolyData)
-      name = "Cross section for "
+      name = _("Cross section: ")
       if (self.lumenSurfaceNode.GetClassName() == "vtkMRMLSegmentationNode"):
         name += self.lumenSurfaceNode.GetSegmentation().GetSegment(self.currentSegmentID).GetName()
       else:
@@ -1431,7 +1435,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
 
   def getPositionMaximumInscribedSphereRadius(self, pointIndex):
     if not self.isCenterlineRadiusAvailable():
-      raise ValueError("Maximum inscribed sphere radius is not available")
+      raise ValueError(_("Maximum inscribed sphere radius is not available"))
     position = np.zeros(3)
     if self.inputCenterlineNode.IsTypeOf("vtkMRMLModelNode"):
       positionLocal = slicer.util.arrayFromModelPoints(self.inputCenterlineNode)[pointIndex]
@@ -1545,13 +1549,13 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
       sphereModelDisplayNode.SetVisibility2D(True)
       sphereModelDisplayNode.SetVisibility3D(True)
       # Set model name
-      name = "Maximum inscribed sphere"
+      name = _("Maximum inscribed sphere: ")
       if self.lumenSurfaceNode:
         if (self.lumenSurfaceNode.GetClassName() == "vtkMRMLSegmentationNode"):
             if self.lumenSurfaceNode.GetSegmentation().GetSegment(self.currentSegmentID):
-              name += " for " + self.lumenSurfaceNode.GetSegmentation().GetSegment(self.currentSegmentID).GetName()
+              name += self.lumenSurfaceNode.GetSegmentation().GetSegment(self.currentSegmentID).GetName()
         else:
-            name += " for " + self.lumenSurfaceNode.GetName()
+            name += self.lumenSurfaceNode.GetName()
       self.maximumInscribedSphereModelNode.SetName(name)
       # Set sphere color
       sphereModelDisplayNode.SetColor(self.maximumInscribedSphereColor[0], self.maximumInscribedSphereColor[1], self.maximumInscribedSphereColor[2])
@@ -1613,14 +1617,14 @@ class CrossSectionAnalysisTest(ScriptedLoadableModuleTest):
     """
     """
 
-DISTANCE_ARRAY_NAME = "Distance"
-MIS_DIAMETER_ARRAY_NAME = "Diameter (MIS)"
-CE_DIAMETER_ARRAY_NAME = "Diameter (CE)"
-CROSS_SECTION_AREA_ARRAY_NAME = "Cross-section area"
-WALL_DIAMETER_ARRAY_NAME = "Wall diameter"
-WALL_CROSS_SECTION_AREA_ARRAY_NAME = "Wall cross-section area"
-SURFACE_AREA_STENOSIS_ARRAY_NAME = "Stenosis by surface area"
-DIAMETER_STENOSIS_ARRAY_NAME = "Stenosis by diameter (CE)"
+DISTANCE_ARRAY_NAME = _("Distance")
+MIS_DIAMETER_ARRAY_NAME = _("Diameter (MIS)")
+CE_DIAMETER_ARRAY_NAME = _("Diameter (CE)")
+CROSS_SECTION_AREA_ARRAY_NAME = _("Cross-section area")
+WALL_DIAMETER_ARRAY_NAME = _("Wall diameter")
+WALL_CROSS_SECTION_AREA_ARRAY_NAME = _("Wall cross-section area")
+SURFACE_AREA_STENOSIS_ARRAY_NAME = _("Stenosis by surface area")
+DIAMETER_STENOSIS_ARRAY_NAME = _("Stenosis by diameter (CE)")
 
 MIS_DIAMETER = "MIS_DIAMETER"
 CE_DIAMETER = "CE_DIAMETER"

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -47,7 +47,7 @@
 - an invisible centerline of a shape markups node used as a tube.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLModelNode</string>
           <string>vtkMRMLMarkupsCurveNode</string>
           <string>vtkMRMLMarkupsShapeNode</string>
@@ -95,7 +95,7 @@ The input centerline is expected to be inside the lumen surface.</string>
            <locale language="English" country="UnitedStates"/>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLSegmentationNode</string>
             <string>vtkMRMLModelNode</string>
            </stringlist>
@@ -144,7 +144,7 @@ The input centerline is expected to be inside the lumen surface.</string>
            <string>Pick the output table to the algorithm.</string>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLTableNode</string>
            </stringlist>
           </property>
@@ -192,7 +192,7 @@ The input centerline is expected to be inside the lumen surface.</string>
            <string>Pick the output plot series to the algorithm.</string>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLPlotSeriesNode</string>
            </stringlist>
           </property>
@@ -387,7 +387,7 @@ The input centerline is expected to be inside the lumen surface.</string>
              <locale language="English" country="UnitedStates"/>
             </property>
             <property name="nodeTypes">
-             <stringlist>
+             <stringlist notr="true">
               <string>vtkMRMLSliceNode</string>
              </stringlist>
             </property>
@@ -478,7 +478,7 @@ The input centerline is expected to be inside the lumen surface.</string>
              <locale language="English" country="UnitedStates"/>
             </property>
             <property name="nodeTypes">
-             <stringlist>
+             <stringlist notr="true">
               <string>vtkMRMLSliceNode</string>
              </stringlist>
             </property>
@@ -1117,6 +1117,7 @@ Caution: values at bifurcations may not have clinical meaning.</string>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/ExtractCenterline/Resources/UI/ExtractCenterline.ui
+++ b/ExtractCenterline/Resources/UI/ExtractCenterline.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>422</width>
-    <height>621</height>
+    <width>554</width>
+    <height>734</height>
    </rect>
   </property>
   <property name="toolTip">
@@ -33,7 +33,7 @@
          <string>Input surface model of the tree. If computation is slow adjust preprocessing parameters in advanced section.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLModelNode</string>
           <string>vtkMRMLSegmentationNode</string>
          </stringlist>
@@ -70,7 +70,7 @@
            <string>Branch endpoints. &quot;Unselected&quot; control points are used as sources, &quot;selected&quot; control points are used as targets.</string>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLMarkupsFiducialNode</string>
            </stringlist>
           </property>
@@ -132,7 +132,7 @@
       <string>Pick node to store parameter set</string>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLScriptedModuleNode</string>
       </stringlist>
      </property>
@@ -185,7 +185,7 @@
             <string>Result of quick centerline network extraction.</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLModelNode</string>
             </stringlist>
            </property>
@@ -225,7 +225,7 @@
             <string>Table containing quantitative analysis of centerline (radius, length, curvature, torsion, etc.)</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLTableNode</string>
             </stringlist>
            </property>
@@ -265,7 +265,7 @@
             <string>Centerline extraction result as a hierarchy of markups curves.</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLMarkupsCurveNode</string>
             </stringlist>
            </property>
@@ -314,7 +314,7 @@
             <string>Centerline extraction result as a model.</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLModelNode</string>
             </stringlist>
            </property>
@@ -354,7 +354,7 @@
             <string>Centerline extraction result as a hierarchy of markups curves.</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLMarkupsCurveNode</string>
             </stringlist>
            </property>
@@ -394,7 +394,7 @@
             <string>Table containing quantitative analysis of centerline (radius, length, curvature, torsion, etc.)</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLTableNode</string>
             </stringlist>
            </property>
@@ -559,7 +559,7 @@
          <string>Save preprocessing result. Useful for quality checks and for making repeated computations faster: preprocessed surface can be used as input surface (and &quot;Preprocess input surface&quot; option can then be disabled).</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLModelNode</string>
          </stringlist>
         </property>
@@ -606,7 +606,7 @@
          <string>Voronoi diagram (similar to medial surface) that is used for computing centerline path between endpoints. It is useful for quality checks and for showing a model where endpoints can be robustly placed on.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLModelNode</string>
          </stringlist>
         </property>
@@ -639,7 +639,7 @@
          <string>Result of mesh error checks. Currently the only check is for presence of non-manifold edges.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLMarkupsFiducialNode</string>
          </stringlist>
         </property>
@@ -733,6 +733,7 @@
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLSpinBox</class>

--- a/GuidedArterySegmentation/GuidedArterySegmentation.py
+++ b/GuidedArterySegmentation/GuidedArterySegmentation.py
@@ -35,17 +35,17 @@ class GuidedArterySegmentation(ScriptedLoadableModule):
     else:
       self.parent.dependencies = ["SegmentEditorFloodFilling","ExtractCenterline"]
     self.parent.contributors = ["Saleem Edah-Tally [Surgeon] [Hobbyist developer]", "Andras Lasso (PerkLab)"]
-    self.parent.helpText = """
+    self.parent.helpText = _("""
 This <a href="https://github.com/vmtk/SlicerExtension-VMTK/">module</a> is intended to create a segmentation from a contrast enhanced CT angioscan, and to finally extract centerlines from the surface model.
 <br><br>It assumes that curve control points are placed in the contrasted lumen.
 <br><br>The 'Flood filling' and 'Split volume' effects of the '<a href="https://github.com/lassoan/SlicerSegmentEditorExtraEffects">Segment editor extra effects</a>' are used.
 <br><br>The '<a href="https://github.com/vmtk/SlicerExtension-VMTK/tree/master/ExtractCenterline/">SlicerExtension-VMTK Extract centerline</a>' module is required.
-"""
+""")
     # TODO: replace with organization, grant and thanks
-    self.parent.acknowledgementText = """
+    self.parent.acknowledgementText = _("""
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc., Andras Lasso, PerkLab,
 and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR013218-12S1.
-"""
+""")
 
 #
 # GuidedArterySegmentationParameterNode
@@ -137,7 +137,7 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
       try:
         self.installExtensionFromServer("SegmentEditorExtraEffects")
       except Exception as e:
-        slicer.util.errorDisplay("Failed to install extension: "+str(e))
+        slicer.util.errorDisplay(_("Failed to install extension: ") + str(e))
         import traceback
         traceback.print_exc()
       
@@ -149,16 +149,16 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
       em.interactive = False
       result = em.updateExtensionsMetadataFromServer(True, True)
       if (not result):
-        raise ValueError(f"Could not update metadata from server to install {extensionName}.")
+        raise ValueError(_("Could not update metadata from server to install {extension}.").format(extension=extensionName))
       
-      reply = slicer.util.confirmYesNoDisplay(f"{extensionName} must be installed. Do you want to install it now ?")
+      reply = slicer.util.confirmYesNoDisplay(_("{extension} must be installed. Do you want to install it now ?").format(extension=extensionName))
       if (not reply):
-        raise ValueError(f"This module cannot be used without {extensionName}.")
+        raise ValueError(_("This module cannot be used without {extension}.").format(extension=extensionName))
       
       if not em.downloadAndInstallExtensionByName(extensionName, True, True):
-        raise ValueError(f"Failed to install {extensionName} extension.")
+        raise ValueError(_("Failed to install {extension} extension.").format(extension=extensionName))
       
-      reply = slicer.util.confirmYesNoDisplay(f"{extensionName} has been installed from server.\n\nSlicer must be restarted. Do you want to restart now ?")
+      reply = slicer.util.confirmYesNoDisplay(_("{extension} has been installed from server.\n\nSlicer must be restarted. Do you want to restart now ?").format(extension=extensionName))
       if reply:
         slicer.util.restart()
 
@@ -172,7 +172,7 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
         return
     numberOfControlPoints = node.GetNumberOfControlPoints()
     if numberOfControlPoints < 3:
-        self.inform("Curve node must have at least 3 points.")
+        self.inform(_("Curve node must have at least 3 points."))
         self._parameterNode.inputCurveNode = None
         return
     # Update UI with previous referenced segmentation. May be changed before logic.process().
@@ -191,14 +191,14 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
         self.ui.tubeDiameterSpinBox.setVisible(True)
         return
     if node.GetShapeName() != slicer.vtkMRMLMarkupsShapeNode().Tube:
-        self.inform("Shape node is not a Tube.")
+        self.inform(_("Shape node is not a Tube."))
         self._shapeNode = None
         self.ui.tubeDiameterSpinBoxLabel.setVisible(True)
         self.ui.tubeDiameterSpinBox.setVisible(True)
         return
     numberOfControlPoints = node.GetNumberOfControlPoints()
     if numberOfControlPoints < 4:
-        self.inform("Shape node must have at least 4 points.")
+        self.inform(_("Shape node must have at least 4 points."))
         self._shapeNode = None
         self.ui.tubeDiameterSpinBoxLabel.setVisible(True)
         self.ui.tubeDiameterSpinBox.setVisible(True)
@@ -368,20 +368,20 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
     """
     try:
         if self._parameterNode.inputCurveNode is None:
-            self.inform("No input curve node specified.")
+            self.inform(_("No input curve node specified."))
             return
         if self._parameterNode.inputCurveNode.GetNumberOfControlPoints() < 3:
-            self.inform("Input curve node must have at least 3 control points.")
+            self.inform(_("Input curve node must have at least 3 control points."))
             return
         if self._parameterNode.inputSliceNode is None:
-            self.inform("No input slice node specified.")
+            self.inform(_("No input slice node specified."))
             return
         # Ensure there's a background volume node.
         sliceNode = self._parameterNode.inputSliceNode
         sliceWidget = slicer.app.layoutManager().sliceWidget(sliceNode.GetName())
         volumeNode = sliceWidget.sliceLogic().GetBackgroundLayer().GetVolumeNode()
         if volumeNode is None:
-            self.inform("No volume node selected in input slice node.")
+            self.inform(_("No volume node selected in input slice node."))
             return
         # Restore logic output objects with referenced ones.
         self.UpdateParameterNodeWithOutputNodes()
@@ -395,7 +395,7 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
         self.ui.outputSegmentationSelector.setCurrentNode(self._parameterNode.outputSegmentation)
 
     except Exception as e:
-      slicer.util.errorDisplay("Failed to compute results: "+str(e))
+      slicer.util.errorDisplay(_("Failed to compute results: ") + str(e))
       import traceback
       traceback.print_exc()
 
@@ -466,9 +466,9 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
   def process(self) -> None:
     import time
     startTime = time.time()
-    logging.info('Processing started')
+    logging.info((_("Processing started")))
     
-    slicer.util.showStatusMessage("Segment editor setup")
+    slicer.util.showStatusMessage(_("Segment editor setup"))
     slicer.app.processEvents()
     """
     Find segment editor widgets.
@@ -610,7 +610,8 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     for i in range(1, numberOfCurveControlPoints - 1):
         # Show progress in status bar. Helpful to wait.
         t = time.time()
-        msg = f'Flood filling : {t-startTime:.2f} seconds - '
+        durationValue = '%.2f' % (t-startTime)
+        msg = _("Flood filling : {duration} seconds - ").format(duration=durationValue)
         self.showStatusMessage((msg, str(i + 1), "/", str(numberOfCurveControlPoints)))
         
         rasPoint = curveControlPoints.GetPoint(i)
@@ -641,13 +642,14 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     
     if not self._parameterNode.extractCenterlines:
         stopTime = time.time()
-        message = f'Processing completed in {stopTime-startTime:.2f} seconds'
+        durationValue = '%.2f' % (stopTime-startTime)
+        message = _("Processing completed in {duration} seconds").format(duration=durationValue)
         logging.info(message)
         slicer.util.showStatusMessage(message, 5000)
         return
     
     #---------------------- Extract centerlines ---------------------
-    slicer.util.showStatusMessage("Extract centerline setup")
+    slicer.util.showStatusMessage(_("Extract centerline setup"))
     slicer.app.processEvents()
     mainWindow.moduleSelector().selectModule('ExtractCenterline')
     if not self._extractCenterlineWidgets:
@@ -715,7 +717,8 @@ class GuidedArterySegmentationLogic(ScriptedLoadableModuleLogic):
     self._extractCenterlineWidgets.outputNetworkGroupBox.collapsed = True
 
     stopTime = time.time()
-    message = f'Processing completed in {stopTime-startTime:.2f} seconds'
+    durationValue = '%.2f' % (stopTime-startTime)
+    message = _("Processing completed in {duration} seconds").format(duration=durationValue)
     logging.info(message)
     slicer.util.showStatusMessage(message, 5000)
 
@@ -742,9 +745,9 @@ class GuidedArterySegmentationTest(ScriptedLoadableModuleTest):
     self.test_GuidedArterySegmentation1()
 
   def test_GuidedArterySegmentation1(self) -> None:
-    self.delayDisplay("Starting the test")
+    self.delayDisplay(_("Starting the test"))
 
-    self.delayDisplay('Test passed')
+    self.delayDisplay(_("Test passed"))
 
 """
 Weird and unusual approach to remote control modules, but very efficient.

--- a/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
+++ b/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
@@ -44,7 +44,7 @@ The control points are assumed to be on the contrasted lumen.</string>
          <locale language="English" country="UnitedStates"/>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLMarkupsCurveNode</string>
          </stringlist>
         </property>
@@ -67,7 +67,7 @@ The control points are assumed to be on the contrasted lumen.</string>
          <bool>true</bool>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>inputCurveNode</string>
+         <string notr="true">inputCurveNode</string>
         </property>
        </widget>
       </item>
@@ -104,7 +104,7 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
          <double>8.000000000000000</double>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>tubeDiameter</string>
+         <string notr="true">tubeDiameter</string>
         </property>
        </widget>
       </item>
@@ -124,7 +124,7 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
          <locale language="English" country="UnitedStates"/>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLSegmentationNode</string>
          </stringlist>
         </property>
@@ -141,7 +141,7 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
          <bool>true</bool>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>outputSegmentation</string>
+         <string notr="true">outputSegmentation</string>
         </property>
        </widget>
       </item>
@@ -156,7 +156,7 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
            <locale language="English" country="UnitedStates"/>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLSliceNode</string>
            </stringlist>
           </property>
@@ -173,7 +173,7 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
            <bool>false</bool>
           </property>
           <property name="SlicerParameterName" stdset="0">
-           <string>inputSliceNode</string>
+           <string notr="true">inputSliceNode</string>
           </property>
          </widget>
         </item>
@@ -341,7 +341,7 @@ If specified, the regular tube diameter above is ignored.</string>
           <number>100</number>
          </property>
          <property name="SlicerParameterName" stdset="0">
-          <string>intensityTolerance</string>
+          <string notr="true">intensityTolerance</string>
          </property>
         </widget>
        </item>
@@ -377,7 +377,7 @@ If specified, the regular tube diameter above is ignored.</string>
           <double>2.000000000000000</double>
          </property>
          <property name="SlicerParameterName" stdset="0">
-          <string>neighbourhoodSize</string>
+          <string notr="true">neighbourhoodSize</string>
          </property>
         </widget>
        </item>
@@ -391,7 +391,7 @@ If specified, the regular tube diameter above is ignored.</string>
       <string>Extract centerlines</string>
      </property>
      <property name="SlicerParameterName" stdset="0">
-      <string>extractCenterlines</string>
+      <string notr="true">extractCenterlines</string>
      </property>
     </widget>
    </item>

--- a/GuidedVeinSegmentation/GuidedVeinSegmentation.py
+++ b/GuidedVeinSegmentation/GuidedVeinSegmentation.py
@@ -5,6 +5,8 @@ from typing import Annotated, Optional
 import vtk
 
 import slicer
+import slicer
+from slicer.i18n import tr as _
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 from slicer.parameterNodeWrapper import (
@@ -30,13 +32,13 @@ class GuidedVeinSegmentation(ScriptedLoadableModule):
         self.parent.categories = ["Vascular Modeling Toolkit"]
         self.parent.dependencies = []
         self.parent.contributors = ["Saleem Edah-Tally [Surgeon] [Hobbyist developer]"]
-        self.parent.helpText = """
+        self.parent.helpText = _("""
 This <a href="https://github.com/vmtk/SlicerExtension-VMTK/">module</a> attempts to segment major veins using effects of the 'Segment editor'.
-"""
-        self.parent.acknowledgementText = """
+""")
+        self.parent.acknowledgementText = _("""
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc., Andras Lasso, PerkLab,
 and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR013218-12S1.
-"""
+""")
 
 #
 # GuidedVeinSegmentationParameterNode
@@ -190,7 +192,7 @@ class GuidedVeinSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationM
         """
         Run processing when user clicks "Apply" button.
         """
-        with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
+        with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
 
             # Compute output
             self.logic.process(self._parameterNode.inputCurve,
@@ -238,19 +240,19 @@ class GuidedVeinSegmentationLogic(ScriptedLoadableModuleLogic):
                 subtractOtherSegments: bool = True) -> None:
 
         if not inputCurve or not inputVolume or not inputSegmentation:
-            raise ValueError("Input curve or volume or segmentation is invalid.")
+            raise ValueError(_("Input curve or volume or segmentation is invalid."))
         
         if (extrusionKernelSize <= 0.0
             or gaussianStandardDeviation <= 0.0
             or seedRadius <= 0.0
             or shellMargin <= 0.0
             or shellThickness <= 0.0):
-            raise ValueError("Extrusion kernel size or Gaussian standard deviation\
-                or seed radius or shell margin or shell thickness is invalid.")
+            raise ValueError(_("Extrusion kernel size or Gaussian standard deviation\
+                or seed radius or shell margin or shell thickness is invalid."))
 
         import time
         startTime = time.time()
-        logging.info('Processing started')
+        logging.info(_("Processing started"))
         
         # Create slicer.modules.SegmentEditorWidget
         slicer.modules.segmenteditor.widgetRepresentation()
@@ -365,7 +367,8 @@ class GuidedVeinSegmentationLogic(ScriptedLoadableModuleLogic):
             inputSegmentation.GetDisplayNode().SetSegmentVisibility(visibleSegmentIDs.GetValue(segmentIndex), True)
         
         stopTime = time.time()
-        logging.info(f'Processing completed in {stopTime-startTime:.2f} seconds')
+        durationValue = '%.2f' % (stopTime-startTime)
+        logging.info(_("Processing completed in {duration} seconds").format(duration=durationValue))
 
 
 #
@@ -391,6 +394,6 @@ class GuidedVeinSegmentationTest(ScriptedLoadableModuleTest):
         self.test_GuidedVeinSegmentation1()
 
     def test_GuidedVeinSegmentation1(self):
-        self.delayDisplay("Starting the test")
+        self.delayDisplay(_("Starting the test"))
 
-        self.delayDisplay('Test passed')
+        self.delayDisplay(_("Test passed"))

--- a/GuidedVeinSegmentation/Resources/UI/GuidedVeinSegmentation.ui
+++ b/GuidedVeinSegmentation/Resources/UI/GuidedVeinSegmentation.ui
@@ -49,7 +49,7 @@
         <bool>true</bool>
        </property>
        <property name="SlicerParameterName" stdset="0">
-        <string>inputCurve</string>
+        <string notr="true">inputCurve</string>
        </property>
       </widget>
      </item>
@@ -89,7 +89,7 @@
         <bool>true</bool>
        </property>
        <property name="SlicerParameterName" stdset="0">
-        <string>inputVolume</string>
+        <string notr="true">inputVolume</string>
        </property>
       </widget>
      </item>
@@ -122,7 +122,7 @@
         <bool>true</bool>
        </property>
        <property name="SlicerParameterName" stdset="0">
-        <string>inputSegmentation</string>
+        <string notr="true">inputSegmentation</string>
        </property>
       </widget>
      </item>
@@ -193,7 +193,7 @@
            <double>18.000000000000000</double>
           </property>
           <property name="SlicerParameterName" stdset="0">
-           <string>shellMargin</string>
+           <string notr="true">shellMargin</string>
           </property>
          </widget>
         </item>
@@ -224,7 +224,7 @@
            <double>5.000000000000000</double>
           </property>
           <property name="SlicerParameterName" stdset="0">
-           <string>extrusionKernelSize</string>
+           <string notr="true">extrusionKernelSize</string>
           </property>
          </widget>
         </item>
@@ -263,7 +263,7 @@ deviation:</string>
            <double>2.000000000000000</double>
           </property>
           <property name="SlicerParameterName" stdset="0">
-           <string>gaussianStandardDeviation</string>
+           <string notr="true">gaussianStandardDeviation</string>
           </property>
          </widget>
         </item>
@@ -315,7 +315,7 @@ deviation:</string>
             <double>1.000000000000000</double>
            </property>
            <property name="SlicerParameterName" stdset="0">
-            <string>seedRadius</string>
+            <string notr="true">seedRadius</string>
            </property>
           </widget>
          </item>
@@ -353,7 +353,7 @@ deviation:</string>
             <double>2.000000000000000</double>
            </property>
            <property name="SlicerParameterName" stdset="0">
-            <string>shellThickness</string>
+            <string notr="true">shellThickness</string>
            </property>
           </widget>
          </item>
@@ -376,7 +376,7 @@ deviation:</string>
             <bool>true</bool>
            </property>
            <property name="SlicerParameterName" stdset="0">
-            <string>subtractOtherSegments</string>
+            <string notr="true">subtractOtherSegments</string>
            </property>
           </widget>
          </item>
@@ -419,6 +419,7 @@ deviation:</string>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/QuickArterySegmentation/Resources/UI/QuickArterySegmentation.ui
+++ b/QuickArterySegmentation/Resources/UI/QuickArterySegmentation.ui
@@ -31,7 +31,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <locale language="English" country="UnitedStates"/>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLMarkupsFiducialNode</string>
          </stringlist>
         </property>
@@ -54,7 +54,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <bool>true</bool>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>inputFiducialNode</string>
+         <string notr="true">inputFiducialNode</string>
         </property>
        </widget>
       </item>
@@ -69,7 +69,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
            <locale language="English" country="UnitedStates"/>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLMarkupsROINode</string>
            </stringlist>
           </property>
@@ -77,7 +77,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
            <bool>true</bool>
           </property>
           <property name="SlicerParameterName" stdset="0">
-           <string>inputROINode</string>
+           <string notr="true">inputROINode</string>
           </property>
          </widget>
         </item>
@@ -129,7 +129,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <string>Select an output segmentation</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLSegmentationNode</string>
          </stringlist>
         </property>
@@ -149,7 +149,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <bool>true</bool>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>outputSegmentationNode</string>
+         <string notr="true">outputSegmentationNode</string>
         </property>
        </widget>
       </item>
@@ -164,7 +164,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
            <locale language="English" country="UnitedStates"/>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLSliceNode</string>
            </stringlist>
           </property>
@@ -181,7 +181,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
            <bool>false</bool>
           </property>
           <property name="SlicerParameterName" stdset="0">
-           <string>inputSliceNode</string>
+           <string notr="true">inputSliceNode</string>
           </property>
          </widget>
         </item>
@@ -265,7 +265,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
           <number>100</number>
          </property>
          <property name="SlicerParameterName" stdset="0">
-          <string>inputIntensityTolerance</string>
+          <string notr="true">inputIntensityTolerance</string>
          </property>
         </widget>
        </item>
@@ -301,7 +301,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
           <double>2.000000000000000</double>
          </property>
          <property name="SlicerParameterName" stdset="0">
-          <string>inputNeighbourhoodSize</string>
+          <string notr="true">inputNeighbourhoodSize</string>
          </property>
         </widget>
        </item>
@@ -329,7 +329,7 @@ It is recommended to generate centerlines on accurate segmentations.</string>
       <bool>false</bool>
      </property>
      <property name="SlicerParameterName" stdset="0">
-      <string>optionExtractCenterlines</string>
+      <string notr="true">optionExtractCenterlines</string>
      </property>
     </widget>
    </item>

--- a/StenosisMeasurement1D/Resources/UI/StenosisMeasurement1D.ui
+++ b/StenosisMeasurement1D/Resources/UI/StenosisMeasurement1D.ui
@@ -30,7 +30,7 @@
          <string>Pick the input markups curve.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLMarkupsCurveNode</string>
          </stringlist>
         </property>
@@ -53,7 +53,7 @@
          <bool>true</bool>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>inputCurveNode</string>
+         <string notr="true">inputCurveNode</string>
         </property>
        </widget>
       </item>

--- a/StenosisMeasurement1D/StenosisMeasurement1D.py
+++ b/StenosisMeasurement1D/StenosisMeasurement1D.py
@@ -31,14 +31,14 @@ class StenosisMeasurement1D(ScriptedLoadableModule):
     self.parent.categories = ["Vascular Modeling Toolkit"]
     self.parent.dependencies = []
     self.parent.contributors = ["Saleem Edah-Tally [Surgeon] [Hobbyist developer]", "Andras Lasso, PerkLab"]
-    self.parent.helpText = """
+    self.parent.helpText = _("""
 This <a href="https://github.com/vmtk/SlicerExtension-VMTK/">module</a> straightens an open input markups curve and displays cumulative and individual lengths between control points. It is intended for quick one dimensional arterial stenosis evaluation, but is actually purpose agnostic.
-"""
+""")
     # TODO: replace with organization, grant and thanks
-    self.parent.acknowledgementText = """
+    self.parent.acknowledgementText = _("""
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc., Andras Lasso, PerkLab,
 and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR013218-12S1.
-"""
+""")
 
 #
 # StenosisMeasurement1DParameterNode
@@ -187,7 +187,7 @@ class StenosisMeasurement1DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
     if outputTable.columnCount == 0:
         outputTable.setColumnCount(4)
         outputTable.setRowCount(numberOfControlPoints - 1)
-        columnLabels = ("Cumulative", "Cumulative %", "Partial", "Partial %")
+        columnLabels = (_("Cumulative"), _("Cumulative %"), _("Partial"), _("Partial %"))
         outputTable.setHorizontalHeaderLabels(columnLabels)
     # Get global variables.
     curveTotalLength = inputCurve.GetCurveLengthWorld()
@@ -272,7 +272,7 @@ class StenosisMeasurement1DLogic(ScriptedLoadableModuleLogic):
         self._observations.append(curveNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointRemovedEvent, self.onCurveControlPointEvent))
         self.process()
     else:
-        msg = "No curve."
+        msg = _("No curve.")
         slicer.util.showStatusMessage(msg, 4000)
         slicer.app.processEvents()
         logging.info(msg)
@@ -380,6 +380,6 @@ class StenosisMeasurement1DTest(ScriptedLoadableModuleTest):
     your test should break so they know that the feature is needed.
     """
 
-    self.delayDisplay("Starting the test")
+    self.delayDisplay(_("Starting the test"))
 
-    self.delayDisplay('Test passed')
+    self.delayDisplay(_("Test passed"))

--- a/StenosisMeasurement2D/StenosisMeasurement2D.py
+++ b/StenosisMeasurement2D/StenosisMeasurement2D.py
@@ -31,14 +31,14 @@ class StenosisMeasurement2D(ScriptedLoadableModule):
     self.parent.categories = ["Vascular Modeling Toolkit"]
     self.parent.dependencies = []
     self.parent.contributors = ["Saleem Edah-Tally [Surgeon] [Hobbyist developer]", "Andras Lasso, PerkLab"]
-    self.parent.helpText = """
+    self.parent.helpText = _("""
 This <a href="https://github.com/vmtk/SlicerExtension-VMTK/">module</a> calculates the surface area of segments cut by a slice plane in its orientation. It is intended for quick two dimensional arterial stenosis evaluation, but is actually purpose agnostic.
-"""
+""")
     # TODO: replace with organization, grant and thanks
-    self.parent.acknowledgementText = """
+    self.parent.acknowledgementText = _("""
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc., Andras Lasso, PerkLab,
 and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR013218-12S1.
-"""
+""")
 #
 # StenosisMeasurement2DParameterNode
 #
@@ -115,27 +115,27 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
     self._optionsMainMenu = self.ui.applyButton.menu()
     self._optionsMainMenu.clear()
     self._optionsMainMenu.setToolTipsVisible(True)
-    self._optionsSubMenu1 = qt.QMenu("More options")
+    self._optionsSubMenu1 = qt.QMenu(_("More options"))
     self._optionsSubMenu1.setToolTipsVisible(True)
-    self._applyToAllSegmentsAction = self._optionsMainMenu.addAction("Apply to all segments")
+    self._applyToAllSegmentsAction = self._optionsMainMenu.addAction(_("Apply to all segments"))
     self._applyToAllSegmentsAction.setCheckable(True)
-    self._applyToAllSegmentsAction.setToolTip("If unchecked, only the selected segment will be processed.")
+    self._applyToAllSegmentsAction.setToolTip(_("If unchecked, only the selected segment will be processed."))
     self._limitToClosestIslandsAction = self._optionsMainMenu.addAction("Limit to closest island")
     self._limitToClosestIslandsAction.setCheckable(True)
     self._limitToClosestIslandsAction.checked = True
-    self._limitToClosestIslandsAction.setToolTip("Calculate the surface area of the closest island to the ficucial control point.")
+    self._limitToClosestIslandsAction.setToolTip(_("Calculate the surface area of the closest island to the ficucial control point."))
     self._optionsMainMenu.addMenu(self._optionsSubMenu1)
     
-    self._createOutputModelsAction = self._optionsSubMenu1.addAction("Create an output model.")
+    self._createOutputModelsAction = self._optionsSubMenu1.addAction(_("Create an output model."))
     self._createOutputModelsAction.setCheckable(True)
     self._createOutputModelsAction.checked = True
-    self._createOutputModelsAction.setToolTip("Create a model for each cut segment.\nThis allows to view the model from which the surface area is calculated.\n\nThe result is influenced by :\n - holes in the segments\n - point placement, if 'Closest island' option is selected,\n - smoothing level in the 'Segment editor'.")
-    self._resetOrientationAction = self._optionsSubMenu1.addAction("Reset control point orientation")
+    self._createOutputModelsAction.setToolTip(_("Create a model for each cut segment.\nThis allows to view the model from which the surface area is calculated.\n\nThe result is influenced by :\n - holes in the segments\n - point placement, if 'Closest island' option is selected,\n - smoothing level in the 'Segment editor'."))
+    self._resetOrientationAction = self._optionsSubMenu1.addAction(_("Reset control point orientation"))
     self._resetOrientationAction.setCheckable(True)
-    self._resetOrientationAction.setToolTip("Click on a control point to reset its recorded slice orientation.")
+    self._resetOrientationAction.setToolTip(_("Click on a control point to reset its recorded slice orientation."))
     self._optionsSubMenu1.addSeparator()
-    self._restoreSliceViewsOrientation = self._optionsSubMenu1.addAction("Restore orientation of all slice views")
-    self._restoreSliceViewsOrientation.setToolTip("... to their default orientation.")
+    self._restoreSliceViewsOrientation = self._optionsSubMenu1.addAction(_("Restore orientation of all slice views"))
+    self._restoreSliceViewsOrientation.setToolTip(_("... to their default orientation."))
     
     # Application connections
     self.ui.inputFiducialSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.observeFiducialNode)
@@ -144,7 +144,7 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
     # Prepare table
     outputTable = self.ui.outputTableWidget
     outputTable.setColumnCount(5)
-    columnLabels = ("Control point", "Segment", "Surface area", "Model visibility", "Segment visibility")
+    columnLabels = (_("Control point"), _("Segment"), _("Surface area"), _("Model visibility"), _("Segment visibility"))
     outputTable.setHorizontalHeaderLabels(columnLabels)
     """
     We need a currentRow() when we toggle the visibility of an output model.
@@ -173,18 +173,18 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
     self.tableMenu.setParent(self.parent)
     
     # Simple menu item to remove a single row.
-    actionRemoveRow = self.tableMenu.addAction("Remove row")
+    actionRemoveRow = self.tableMenu.addAction(_("Remove row"))
     actionRemoveRow.setData(OUTPUT_TABLE_MENU_REMOVE_ROW)
     actionRemoveRow.connect("triggered()", self.onTableMenuItem)
     
     # Simple menu item to remove all rows.
-    actionEmptyTable = self.tableMenu.addAction("Empty table")
+    actionEmptyTable = self.tableMenu.addAction(_("Empty table"))
     actionEmptyTable.setData(OUTPUT_TABLE_MENU_EMPTY_TABLE)
     actionEmptyTable.connect("triggered()", self.onTableMenuItem)
     
     self.tableMenu.addSeparator()
     # Clicking anywhere does not hide menu.
-    actionCancel = self.tableMenu.addAction("Dismiss menu")
+    actionCancel = self.tableMenu.addAction(_("Dismiss menu"))
     actionCancel.connect("triggered()", self.onTableMenuItem)
     """
     Set menu position.
@@ -233,7 +233,7 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
   def onShowSegmentCheckBox(self, checkStatus) -> None:
     segmentation = self.ui.inputSegmentSelector.currentNode()
     if not segmentation:
-        self.showStatusMessage(("Input segmentation is invalid",), True)
+        self.showStatusMessage((_("Input segmentation is invalid"),), True)
         return
     outputTable = self.ui.outputTableWidget
     segmentCellItem = outputTable.item(outputTable.currentRow(), 1)
@@ -323,12 +323,12 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
         self.showStatusMessage((_("Select a fiducial node"),), True)
         return
     if not self.ui.inputSegmentSelector.currentNode():
-        self.showStatusMessage(("Select a segmentation node",), True)
+        self.showStatusMessage((_("Select a segmentation node"),), True)
         return
     if int(self.currentControlPointID) < 0:
-        self.showStatusMessage(("Click on a fiducial control point",), True)
+        self.showStatusMessage((_("Click on a fiducial control point"),), True)
         return
-    with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
+    with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
         # Get control point index, position and label.
         fiducialNode = self._parameterNode.inputFiducialNode
         controlPointIndex = fiducialNode.GetNthControlPointIndexByID(self.currentControlPointID)
@@ -473,13 +473,13 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
         # Unobserve an already observed input fiducial node.
         self._parameterNode.inputFiducialNode.GetDisplayNode().RemoveObserver(self.fiducialDisplayNodeObservation)
         self.fiducialDisplayNodeObservation = None
-        message = ("Fiducial node is no longer observed",)
+        message = (_("Fiducial node is no longer observed"),)
         self.showStatusMessage(message)
     # Observe a selected fiducial node.
     displayNode = fiducialNode.GetDisplayNode()
     if displayNode:
         self.fiducialDisplayNodeObservation = displayNode.AddObserver(slicer.vtkMRMLMarkupsFiducialDisplayNode.JumpToPointEvent, self.onJumpToPoint)
-        message = ("Fiducial node is being observed",)
+        message = (_("Fiducial node is being observed"),)
         self.showStatusMessage(message)
 
   """
@@ -492,7 +492,7 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
     # Use the UI input slice node.
     mrmlSliceNode = self._parameterNode.inputSliceNode
     if not mrmlSliceNode:
-        message = ("Slice node not set",)
+        message = (_("Slice node not set"),)
         self.showStatusMessage(message, True)
         return
     # Get control point orientation matrix.
@@ -509,7 +509,7 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
                 value = sliceToRAS.GetElement(row, col)
                 sliceToRASOrientationMatrix.SetElement(row, col, value)
         fiducialNode.SetNthControlPointOrientationMatrixWorld(controlPointIndex, sliceToRASOrientationMatrix)
-        message = ("Slice orientation recorded",)
+        message = (_("Slice orientation recorded"),)
         self.showStatusMessage(message)
     else:
         # Restore the orientation part of a sliceToRAS matrix.
@@ -519,14 +519,14 @@ class StenosisMeasurement2DWidget(ScriptedLoadableModuleWidget, VTKObservationMi
                 sliceToRAS.SetElement(row, col, value)
         # Update slice orientation in UI.
         mrmlSliceNode.UpdateMatrices()
-        message = ("Slice orientation restored",)
+        message = (_("Slice orientation restored"),)
         self.showStatusMessage(message)
     
     # Execute a request to reset a control point orientation matrix.
     if self._resetOrientationAction.checked:
         identityMatrix = vtk.vtkMatrix3x3()
         fiducialNode.SetNthControlPointOrientationMatrixWorld(controlPointIndex, identityMatrix)
-        message = ("Reset orientation at point", fiducialNode.GetNthControlPointLabel(controlPointIndex))
+        message = (_("Reset orientation at point"), fiducialNode.GetNthControlPointLabel(controlPointIndex))
         self.showStatusMessage(message)
     # Always set the checkbox to false.
     self._resetOrientationAction.checked = False
@@ -563,13 +563,13 @@ class StenosisMeasurement2DLogic(ScriptedLoadableModuleLogic):
                     center, normal, closestIsland = True,
                     createModel = False, controlPointLabel = None):
     if not inputSegmentation:
-      raise ValueError("Input segmentation is invalid")
+      raise ValueError(_("Input segmentation is invalid"))
     if segmentID == "":
-      raise ValueError("Input segment ID is invalid")
+      raise ValueError(_("Input segment ID is invalid"))
 
     import time
     startTime = time.time()
-    logging.info('Processing started')
+    logging.info(_("Processing started"))
     
     # ---------------------- Generate cut polydata ---------
     closedSurfacePolyData = vtk.vtkPolyData()
@@ -620,7 +620,8 @@ class StenosisMeasurement2DLogic(ScriptedLoadableModuleLogic):
             cutModel.GetDisplayNode().SetColor(segment.GetColor())
     
     stopTime = time.time()
-    logging.info(f'Processing completed in {stopTime-startTime:.2f} seconds')
+    durationValue = '%.2f' % (stopTime - startTime)
+    logging.info(_("Processing completed in {duration} seconds").format(duration = durationValue))
     return (surfaceArea, cutModel)
 
   # Helper function.
@@ -672,9 +673,9 @@ class StenosisMeasurement2DTest(ScriptedLoadableModuleTest):
     your test should break so they know that the feature is needed.
     """
 
-    self.delayDisplay("Starting the test")
+    self.delayDisplay(_("Starting the test"))
 
-    self.delayDisplay('Test passed')
+    self.delayDisplay(_("Test passed"))
 
 # Menu constants.
 MENU_CANCEL = 0

--- a/StenosisMeasurement3D/Resources/UI/qSlicerStenosisMeasurement3DModuleWidget.ui
+++ b/StenosisMeasurement3D/Resources/UI/qSlicerStenosisMeasurement3DModuleWidget.ui
@@ -29,7 +29,7 @@
         <string>Select an input shape (tube) node, drawn to represent the vascular wall.</string>
        </property>
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLMarkupsShapeNode</string>
         </stringlist>
        </property>
@@ -61,7 +61,7 @@
 The first and second points are the boundaries between which the analysis will be performed. They should not be at the very ends of the wall surface for accurate results.</string>
        </property>
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLMarkupsFiducialNode</string>
         </stringlist>
        </property>
@@ -242,7 +242,7 @@ This should ideally exceed the wall surface a little, and must not be bifurcated
               <string>Show the wall between the boundary points as a model.</string>
              </property>
              <property name="nodeTypes">
-              <stringlist>
+              <stringlist notr="true">
                <string>vtkMRMLModelNode</string>
               </stringlist>
              </property>
@@ -273,7 +273,7 @@ This should ideally exceed the wall surface a little, and must not be bifurcated
               <string>Show the lumen between the boundary points as a model.</string>
              </property>
              <property name="nodeTypes">
-              <stringlist>
+              <stringlist notr="true">
                <string>vtkMRMLModelNode</string>
               </stringlist>
              </property>

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
@@ -111,30 +111,30 @@ void qSlicerStenosisMeasurement3DModuleWidget::onApply()
   
   if (!shapeNode || !fiducialNode || !segmentationNode || currentSegmentID.empty())
   {
-    this->showStatusMessage("Insufficient input.", 5000);
+    this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Insufficient input."), 5000);
     return;
   }
   vtkMRMLMarkupsShapeNode * shapeNodeReal = vtkMRMLMarkupsShapeNode::SafeDownCast(shapeNode);
   if (!shapeNodeReal || shapeNodeReal->GetShapeName() != vtkMRMLMarkupsShapeNode::Tube)
   {
-    this->showStatusMessage("Bad shape node.", 5000);
+    this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Wrong shape node."), 5000);
     return;
   }
   vtkMRMLMarkupsFiducialNode * fiducialNodeReal = vtkMRMLMarkupsFiducialNode::SafeDownCast(fiducialNode);
   if (!fiducialNodeReal)
   {
-    this->showStatusMessage("Inconsistent fiducial input.", 5000);
+    this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Inconsistent fiducial input."), 5000);
     return;
   }
   if (fiducialNodeReal->GetNumberOfControlPoints() < 2)
   {
-    this->showStatusMessage("Two fiducial input points are mandatory.", 5000);
+    this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Two fiducial input points are mandatory."), 5000);
     return;
   }
   vtkMRMLSegmentationNode * segmentationNodeReal = vtkMRMLSegmentationNode::SafeDownCast(segmentationNode);
   if (!segmentationNodeReal)
   {
-    this->showStatusMessage("Inconsistent segmentation input.", 5000);
+    this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Inconsistent segmentation input."), 5000);
     return;
   }
   
@@ -148,7 +148,7 @@ void qSlicerStenosisMeasurement3DModuleWidget::onApply()
                                      fiducialNodeReal, wallOpen, lumenOpen, wallClosed, lumenClosed);
   if (length < 0.0)
   {
-    this->showStatusMessage("Processing failed.", 5000);
+    this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Processing failed."), 5000);
     return;
   }
   // Finally show result.


### PR DESCRIPTION
Hi @lassoan, @pieper,

This PR is intended to make most modules of SlicerVMTK translatable. It is based on branch 'ParameterNodeWrapperAndOther' which is in PR #107, and not on the 'master' branch.

The modifications follow [this](https://discourse.slicer.org/t/how-to-mark-some-strings-as-translatable/34008) discussion and the link to the [translation guide](https://github.com/Slicer/SlicerLanguagePacks/blob/main/DevelopersManual.md).

I don't claim this PR is 100% fit for a merge. Please advise about required improvements.

@lassoan, please note I have felt free to modify 'ExtractCenterline' module also in 2c40a32. This patch can be easily dropped if you deem it necessary.

This PR is intended to be merged in 'Rebase and merge' mode. If PR #107 is not accepted for a merge, I can still modify this PR to rebase it on 'master'.

Your comments are welcome.

Regards.
