### PR TITLE
Generate centerline curves in addition to models.

### DIFF
--- a/CenterlineDisassembly/Resources/UI/CenterlineDisassembly.ui
+++ b/CenterlineDisassembly/Resources/UI/CenterlineDisassembly.ui
@@ -55,7 +55,7 @@
         <bool>false</bool>
        </property>
        <property name="SlicerParameterName" stdset="0">
-        <string>inputCenterline</string>
+        <string notr="true">inputCenterline</string>
        </property>
       </widget>
      </item>
@@ -67,7 +67,11 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QComboBox" name="componentComboBox"/>
+      <widget class="ctkCheckableComboBox" name="componentCheckableComboBox">
+       <property name="toolTip">
+        <string>Select the output components.</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -85,6 +89,44 @@
     </spacer>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="optionCreateModelsToolButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Create centerline models</string>
+       </property>
+       <property name="text">
+        <string>Create models</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ctkMenuButton" name="optionCreateCurvesMenuButton">
+       <property name="toolTip">
+        <string>Create centerline curves.
+
+Upon curve creation, the visibility of the names can be specified via the menu.</string>
+       </property>
+       <property name="text">
+        <string>Create curves</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QPushButton" name="applyButton">
      <property name="enabled">
       <bool>true</bool>
@@ -100,6 +142,16 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ctkCheckableComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ctkCheckableComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkMenuButton</class>
+   <extends>QPushButton</extends>
+   <header>ctkMenuButton.h</header>
+  </customwidget>
   <customwidget>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>

--- a/Docs/CenterlineDisassembly.md
+++ b/Docs/CenterlineDisassembly.md
@@ -8,7 +8,7 @@ The centerline must have been created with the 'Extract centerline' module.
 
 ### Usage
 
-Select a centerline model node, the components to extract and apply. The result can be browsed in the 'Models' module's widget.
+Select a centerline model node, the components to extract, the output type and apply. The result can be browsed in the 'Models' and 'Markups' modules' widgets.
 
 The components of a centerline can be:
 


### PR DESCRIPTION
Hi,

Please consider this PR that allows to create centerline curves in addition to models in 'Centerline disassembly' module.

It calls 'ExtractCenterline' module to generate the curves.

The major interest in my view is smoother browsing in 'CrossSectionAnalysis' module. Another added value may include the resampling feature of markups curves.

Thank you.

@lassoan 
