### PR TITLE
Updates after translation.

### DIFF
--- a/BranchClipper/Resources/UI/qSlicerBranchClipperModuleWidget.ui
+++ b/BranchClipper/Resources/UI/qSlicerBranchClipperModuleWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -205,6 +205,7 @@ The input centerline is expected to be inside the lumen surface.</string>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
+++ b/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
@@ -159,7 +159,7 @@ void qSlicerBranchClipperModuleWidget::onApply()
   
   // Debranch now. Execute() can be a long process on heavy segmentations.
   timer->StartTimer();
-  this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("Debranching, please wait..."));
+  this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("Disassembling, please wait..."));
 
   vtkNew<vtkSlicerBranchClipperLogic> logic;
   logic->SetCenterlines(centerlines);

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -27,8 +27,7 @@ class CrossSectionAnalysis(ScriptedLoadableModule):
     self.parent.dependencies = []
     self.parent.contributors = ["Saleem Edah-Tally (Surgeon) (Hobbyist developer)", "Andras Lasso (PerkLab)"]
     self.parent.helpText = _("""
-This module describes cross-sections along a VMTK centerline model, a VMTK centerline markups curve or an arbitrary markups curve. Documentation is available
-    <a href="https://github.com/vmtk/SlicerExtension-VMTK/">here</a>.
+This module describes cross-sections along a VMTK centerline model, a VMTK centerline markups curve or an arbitrary markups curve. Documentation is available <a href="https://github.com/vmtk/SlicerExtension-VMTK/">here</a>.
 """)
     self.parent.acknowledgementText = _("""
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc., Andras Lasso, PerkLab,

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -447,7 +447,7 @@ The input centerline is expected to be inside the lumen surface.</string>
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>Rotate slice view around its Z-axis to restore anatomic orientation</string>
+             <string>Rotation angle for longitudinal slice view</string>
             </property>
             <property name="statusTip">
              <string/>
@@ -496,7 +496,7 @@ The input centerline is expected to be inside the lumen surface.</string>
           <item row="2" column="0">
            <widget class="QLabel" name="label_5">
             <property name="toolTip">
-             <string>Rotation angle for longitudinal slice view</string>
+             <string/>
             </property>
             <property name="text">
              <string>Rotate:</string>

--- a/StenosisMeasurement1D/Resources/UI/StenosisMeasurement1D.ui
+++ b/StenosisMeasurement1D/Resources/UI/StenosisMeasurement1D.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>StraightCurveGauge</class>
- <widget class="qMRMLWidget" name="StraightCurveGauge">
+ <class>StenosisMeasurement1D</class>
+ <widget class="qMRMLWidget" name="StenosisMeasurement1D">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -113,7 +113,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>StraightCurveGauge</sender>
+   <sender>StenosisMeasurement1D</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>inputMarkupsSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>

--- a/StenosisMeasurement2D/Resources/UI/StenosisMeasurement2D.ui
+++ b/StenosisMeasurement2D/Resources/UI/StenosisMeasurement2D.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ObliqueSegmentSurfaceArea</class>
- <widget class="qMRMLWidget" name="ObliqueSegmentSurfaceArea">
+ <class>StenosisMeasurement2D</class>
+ <widget class="qMRMLWidget" name="StenosisMeasurement2D">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -43,7 +43,7 @@
              <string>Select an input slice view.</string>
             </property>
             <property name="nodeTypes">
-             <stringlist>
+             <stringlist notr="true">
               <string>vtkMRMLSliceNode</string>
              </stringlist>
             </property>
@@ -60,7 +60,7 @@
              <bool>false</bool>
             </property>
             <property name="SlicerParameterName" stdset="0">
-             <string>inputSliceNode</string>
+             <string notr="true">inputSliceNode</string>
             </property>
            </widget>
           </item>
@@ -79,7 +79,7 @@
 Clicking at a control point allows to track the slice orientation in the selected slice node, on top of the usual jump behaviour. This tracking is scene-wide only, it is not saved with the scene.</string>
             </property>
             <property name="nodeTypes">
-             <stringlist>
+             <stringlist notr="true">
               <string>vtkMRMLMarkupsFiducialNode</string>
              </stringlist>
             </property>
@@ -102,7 +102,7 @@ Clicking at a control point allows to track the slice orientation in the selecte
              <bool>false</bool>
             </property>
             <property name="SlicerParameterName" stdset="0">
-             <string>inputFiducialNode</string>
+             <string notr="true">inputFiducialNode</string>
             </property>
            </widget>
           </item>
@@ -186,6 +186,7 @@ Right click for more.</string>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>
@@ -202,7 +203,7 @@ Right click for more.</string>
  <resources/>
  <connections>
   <connection>
-   <sender>ObliqueSegmentSurfaceArea</sender>
+   <sender>StenosisMeasurement2D</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>inputSliceNodeSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
@@ -218,7 +219,7 @@ Right click for more.</string>
    </hints>
   </connection>
   <connection>
-   <sender>ObliqueSegmentSurfaceArea</sender>
+   <sender>StenosisMeasurement2D</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>inputFiducialSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
@@ -234,7 +235,7 @@ Right click for more.</string>
    </hints>
   </connection>
   <connection>
-   <sender>ObliqueSegmentSurfaceArea</sender>
+   <sender>StenosisMeasurement2D</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>inputSegmentSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>


### PR DESCRIPTION
- Replace non-dictionary word: Debranching -> Disassembling (BranchClipper).
- Remove window title (BranchClipper).
- Change UI widget's name to be consistent with the Python implementation files: StraightCurveGauge -> StenosisMeasurement1D ObliqueSegmentSurfaceArea -> StenosisMeasurement2D
It remains to see if the translated strings in the Python files get used at runtime.
- Mark nodeType property of qMRMLNodeComboBox as not translatable (StenosisMeasurement2D).
- Mark SlicerParameterName property as not translatable (StenosisMeasurement2D).
- Move tooltip text to the right widget (CrossSectionAnalysis).
- Remove not needed new line and spaces (CrossSectionAnalysis).