### PR TITLE
Update acknowledgement and wording.

### DIFF
--- a/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
+++ b/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
@@ -159,7 +159,7 @@ void qSlicerBranchClipperModuleWidget::onApply()
   
   // Debranch now. Execute() can be a long process on heavy segmentations.
   timer->StartTimer();
-  this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("Disassembling, please wait..."));
+  this->showStatusMessage(qSlicerBranchClipperModuleWidget::tr("Splitting, please wait..."));
 
   vtkNew<vtkSlicerBranchClipperLogic> logic;
   logic->SetCenterlines(centerlines);

--- a/CenterlineDisassembly/CenterlineDisassembly.py
+++ b/CenterlineDisassembly/CenterlineDisassembly.py
@@ -35,6 +35,7 @@ class CenterlineDisassembly(ScriptedLoadableModule):
         self.parent.contributors = ["Saleem Edah-Tally [Surgeon] [Hobbyist developer]"]
         self.parent.helpText = _("""
 Break down a centerline model into parts.
+This module makes use of the 'ExtractCenterline' module to generate curves.
 See more information in the <a href="https://github.com/vmtk/SlicerExtension-VMTK/">module documentation</a>.
 """)
         self.parent.acknowledgementText = _("""

--- a/Docs/CenterlineDisassembly.md
+++ b/Docs/CenterlineDisassembly.md
@@ -4,6 +4,8 @@ This module can split a bifurcated centerline model into multiple components. It
 
 The input centerline must have been created with the 'Extract centerline' module.
 
+This module makes use of the 'Extract centerline' module to generate curves.
+
 ![CenterlineDisassembly](CenterlineDisassembly_0.png)
 
 ### Usage


### PR DESCRIPTION
This PR does the following:
 
1. Explicitly mention that the 'ExtractCenterline' module is used to generate curves in the 'CenterlineDisassemby' module.
2. Use a more appropriate wording in 'BranchClipper' module.

(1) is considered important enough to mandate a PR.
