### PR TITLE
Improve parameter node handling.

### DIFF
--- a/GuidedArterySegmentation/GuidedArterySegmentation.py
+++ b/GuidedArterySegmentation/GuidedArterySegmentation.py
@@ -140,6 +140,8 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
     logging.info(message)
 
   def onCurveNode(self, node) -> None:
+    if not self._parameterNode:
+      return;
     self._parameterNode.inputCurveNode = node
     if node is None:
         return
@@ -243,9 +245,9 @@ class GuidedArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservatio
     Called just after the scene is closed.
     """
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
+    self.logic.initMemberVariables()
     if self.parent.isEntered:
       self.initializeParameterNode()
-    self.logic.initMemberVariables()
 
   def initializeParameterNode(self) -> None:
     """

--- a/QuickArterySegmentation/QuickArterySegmentation.py
+++ b/QuickArterySegmentation/QuickArterySegmentation.py
@@ -137,6 +137,8 @@ class QuickArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservation
     logging.info(message)
 
   def onFiducialNode(self, node) -> None:
+    if not self._parameterNode:
+      return
     self._parameterNode.inputFiducialNode = node # This functions seems to be called before parameter node gets updated.
     if node is None:
         return
@@ -247,9 +249,9 @@ class QuickArterySegmentationWidget(ScriptedLoadableModuleWidget, VTKObservation
     Called just after the scene is closed.
     """
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
+    self.logic.initMemberVariables()
     if self.parent.isEntered:
       self.initializeParameterNode()
-    self.logic.initMemberVariables()
 
   def initializeParameterNode(self) -> None:
     """


### PR DESCRIPTION
1. Reset variables in logic before fetching a clean parameter node when a scene is closed.
   - The widget's parameter node would otherwise remain None. Reloading in developer mode is straightforward. Else, Slicer would have to be restarted.

2. Check whether parameter node is None on node selection.
   - (1) renders this moot however.