### PR TITLE
Pass the right variable to the VMTK clipper.

### DIFF
--- a/BranchClipper/Logic/vtkSlicerBranchClipperLogic.cxx
+++ b/BranchClipper/Logic/vtkSlicerBranchClipperLogic.cxx
@@ -129,7 +129,7 @@ void vtkSlicerBranchClipperLogic::Execute()
   {
     clipper->ClipAllCenterlineGroupIdsOn();
   }
-  clipper->SetGenerateClippedOutput(this->InsideOut);
+  clipper->SetGenerateClippedOutput(this->GenerateClippedOutput);
   clipper->Update();
   
   if (!this->InsideOut)


### PR DESCRIPTION
InsideOut was being used instead of GenerateClippedOutput.