### PR TITLE
Remove duplicated variable.

### DIFF
--- a/BranchClipper/Logic/vtkSlicerBranchClipperLogic.cxx
+++ b/BranchClipper/Logic/vtkSlicerBranchClipperLogic.cxx
@@ -132,7 +132,7 @@ void vtkSlicerBranchClipperLogic::Execute()
   clipper->SetGenerateClippedOutput(this->GenerateClippedOutput);
   clipper->Update();
   
-  if (!this->InsideOut)
+  if (!this->GenerateClippedOutput)
   {
     this->Output->DeepCopy(clipper->GetOutput());
   }

--- a/BranchClipper/Logic/vtkSlicerBranchClipperLogic.h
+++ b/BranchClipper/Logic/vtkSlicerBranchClipperLogic.h
@@ -79,9 +79,6 @@ public:
   vtkSetMacro(ClipAllCenterlineGroupIds,int);
   vtkGetMacro(ClipAllCenterlineGroupIds,int);
   vtkBooleanMacro(ClipAllCenterlineGroupIds,int);
-  vtkSetMacro(InsideOut,int);
-  vtkGetMacro(InsideOut,int);
-  vtkBooleanMacro(InsideOut,int);
   vtkGetObjectMacro(Output, vtkPolyData);
   vtkGetObjectMacro(OutputCenterlines, vtkPolyData);
   
@@ -128,7 +125,6 @@ protected:
   vtkIdList * CenterlineGroupIds = nullptr;
   int GenerateClippedOutput = 0;
   int ClipAllCenterlineGroupIds = 0;
-  int InsideOut = 0;
   
   vtkSmartPointer<vtkPolyData> Output = nullptr;
   vtkSmartPointer<vtkPolyData> OutputCenterlines = nullptr;


### PR DESCRIPTION
InsideOut is a synonym of GenerateClippedOutput, the latter being kept to be consistent with vtkvmtkPolyDataCenterlineGroupsClipper. InsideOut is used in vmtkbranchclipper.py.

Sorry for 2 PRs in a short interval of time.