### PR TITLE
Return a copy of the input model's polydata

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -78,6 +78,8 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self._lumenRegions = []
     # The paint effect button must not be visible by default.
     self.ui.surfaceInformationPaintToolButton.setVisible(False)
+    # Position the crosshair on a lumen region.
+    self.crosshair=slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLCrosshairNode")
 
     self.initializeParameterNode()
 
@@ -780,6 +782,8 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         firstPoint = region.GetPoint(0)
         for sliceNode in sliceNodes:
           slicer.vtkMRMLSliceNode.JumpSliceByCentering(sliceNode, *firstPoint)
+        
+        self.crosshair.SetCrosshairRAS(firstPoint)
       
     self.ui.surfaceInformationLabel.setText(label)
   

--- a/ExtractCenterline/ExtractCenterline.py
+++ b/ExtractCenterline/ExtractCenterline.py
@@ -464,13 +464,13 @@ class ExtractCenterlineLogic(ScriptedLoadableModuleLogic):
             parameters["aggressiveness"] = decimationAggressiveness
             decimation = slicer.modules.decimation
             cliNode = slicer.cli.runSync(decimation, None, parameters)
-            outputSurfacePolyData = outputSurfaceModelNode.GetPolyData()
+            surfacePolyData = outputSurfaceModelNode.GetPolyData()
             slicer.mrmlScene.RemoveNode(inputSurfaceModelNode)
             slicer.mrmlScene.RemoveNode(outputSurfaceModelNode)
             slicer.mrmlScene.RemoveNode(cliNode)
 
         surfaceCleaner = vtk.vtkCleanPolyData()
-        surfaceCleaner.SetInputData(outputSurfacePolyData)
+        surfaceCleaner.SetInputData(surfacePolyData)
         surfaceCleaner.Update()
 
         surfaceTriangulator = vtk.vtkTriangleFilter()

--- a/ExtractCenterline/ExtractCenterline.py
+++ b/ExtractCenterline/ExtractCenterline.py
@@ -429,7 +429,9 @@ class ExtractCenterlineLogic(ScriptedLoadableModuleLogic):
             logging.error(_("Invalid input surface node"))
             return None
         if surfaceNode.IsA("vtkMRMLModelNode"):
-            return surfaceNode.GetPolyData()
+            polyData = vtk.vtkPolyData()
+            polyData.DeepCopy(surfaceNode.GetPolyData())
+            return polyData
         elif surfaceNode.IsA("vtkMRMLSegmentationNode"):
             # Segmentation node
             polyData = vtk.vtkPolyData()

--- a/ExtractCenterline/ExtractCenterline.py
+++ b/ExtractCenterline/ExtractCenterline.py
@@ -464,13 +464,13 @@ class ExtractCenterlineLogic(ScriptedLoadableModuleLogic):
             parameters["aggressiveness"] = decimationAggressiveness
             decimation = slicer.modules.decimation
             cliNode = slicer.cli.runSync(decimation, None, parameters)
-            surfacePolyData = outputSurfaceModelNode.GetPolyData()
+            outputSurfacePolyData = outputSurfaceModelNode.GetPolyData()
             slicer.mrmlScene.RemoveNode(inputSurfaceModelNode)
             slicer.mrmlScene.RemoveNode(outputSurfaceModelNode)
             slicer.mrmlScene.RemoveNode(cliNode)
 
         surfaceCleaner = vtk.vtkCleanPolyData()
-        surfaceCleaner.SetInputData(surfacePolyData)
+        surfaceCleaner.SetInputData(outputSurfacePolyData)
         surfaceCleaner.Update()
 
         surfaceTriangulator = vtk.vtkTriangleFilter()


### PR DESCRIPTION
The input parameter 'surfacePolyData' is reassigned to a temporary model explicitly scheduled for removal. Using a local variable instead.

Hello @lassoan,

While investing a weird crash, I came up to this patch that resolves the issue in my workflow. I'm not sure if the current code needs to be changed. Please advise when possible.

In particular, is it correct that an input parameter in Python gets reassigned to a temporary object?

UPDATE
The first patch is reverted as on repeat runs, the crash still happens.
The second patch seems more robust.

Thanks.
