### PR TITLE
General maintenance

### DIFF
--- a/ArterialCalcificationPreProcessor/ArterialCalcificationPreProcessor.py
+++ b/ArterialCalcificationPreProcessor/ArterialCalcificationPreProcessor.py
@@ -106,6 +106,7 @@ class ArterialCalcificationPreProcessorWidget(ScriptedLoadableModuleWidget, VTKO
         self.ui.applyButton.menu().clear()
         self._show3DAction = qt.QAction(_("Show 3D on success"))
         self._show3DAction.setCheckable(True)
+        self._show3DAction.setChecked(True)
         self.ui.applyButton.menu().addAction(self._show3DAction)
 
         # Buttons
@@ -241,9 +242,9 @@ class ArterialCalcificationPreProcessorLogic(ScriptedLoadableModuleLogic):
         maxSegmentHU = float(ssLogic.getStatisticsValueAsString(segmentID, "ScalarVolumeSegmentStatisticsPlugin.max"))
         maxVolumeHU = inputVolume.GetImageData().GetScalarRange()[1]
         
-        # Create slicer.modules.SegmentEditorWidget
-        slicer.modules.segmenteditor.widgetRepresentation()
-        seWidget = slicer.modules.SegmentEditorWidget.editor
+        # Create segment editor object if needed.
+        segmentEditorModuleWidget = slicer.util.getModuleWidget("SegmentEditor")
+        seWidget = segmentEditorModuleWidget.editor
         seWidget.mrmlSegmentEditorNode().SetMaskMode(slicer.vtkMRMLSegmentationNode.EditAllowedEverywhere)
         seWidget.mrmlSegmentEditorNode().SourceVolumeIntensityMaskOff()
         seWidget.mrmlSegmentEditorNode().SetOverwriteMode(seWidget.mrmlSegmentEditorNode().OverwriteNone)

--- a/BranchClipper/Resources/UI/qSlicerBranchClipperModuleWidget.ui
+++ b/BranchClipper/Resources/UI/qSlicerBranchClipperModuleWidget.ui
@@ -50,13 +50,13 @@
          <bool>false</bool>
         </property>
         <property name="removeEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="editEnabled">
          <bool>true</bool>
         </property>
         <property name="renameEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -93,9 +93,12 @@ The input centerline is expected to be inside the lumen surface.</string>
            <bool>false</bool>
           </property>
           <property name="removeEnabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="editEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="renameEnabled">
            <bool>true</bool>
           </property>
          </widget>

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -708,7 +708,9 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
       # If there's only 1 region, there's nothing to fix.
       self.ui.surfaceInformationPaintToolButton.setVisible((numberOfRegions > 1) and self.checkAndSetSegmentEditor(True))
       if (numberOfRegions == 1) and (self.checkAndSetSegmentEditor(False)):
-        seWidget = slicer.modules.SegmentEditorWidget.editor
+        # Create segment editor object if needed.
+        segmentEditorModuleWidget = slicer.util.getModuleWidget("SegmentEditor")
+        seWidget = segmentEditorModuleWidget.editor
         seWidget.setActiveEffectByName(None)
     else:
       self.ui.surfaceInformationPaintToolButton.setVisible(False)
@@ -726,20 +728,11 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
       logging.error("Invalid input segment ID.")
       return False
     
-    # Set a default brush size of 3% if we initialise SegmentEditorWidget.
-    # Otherwise, it would be 1%.
-    try:
-      seWidget = slicer.modules.SegmentEditorWidget.editor
-    except Exception as e:
-      # Create slicer.modules.SegmentEditorWidget
-      slicer.modules.segmenteditor.widgetRepresentation()
-      seWidget = slicer.modules.SegmentEditorWidget.editor
-      seWidget.setActiveEffectByName("Paint")
-      effect = seWidget.activeEffect()
-      # setParameter() is bad here. It sets brush size within 2% to 4% using the spinbox.
-      effect.setCommonParameter("BrushRelativeDiameter", str(3.0))
-    
+    # Create segment editor object if needed.
+    segmentEditorModuleWidget = slicer.util.getModuleWidget("SegmentEditor")
+    seWidget = segmentEditorModuleWidget.editor
     seWidget.setActiveEffectByName(None)
+    
     if not setNodes:
       return True
     
@@ -800,7 +793,9 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
       logging.info(_("Could not prepare the segment editor."))
       return
 
-    seWidget = slicer.modules.SegmentEditorWidget.editor
+    # Create segment editor object if needed.
+    segmentEditorModuleWidget = slicer.util.getModuleWidget("SegmentEditor")
+    seWidget = segmentEditorModuleWidget.editor
     
     if checked:
       seWidget.setActiveEffectByName("Paint")

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -69,13 +69,13 @@
          <bool>false</bool>
         </property>
         <property name="removeEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="editEnabled">
          <bool>true</bool>
         </property>
         <property name="renameEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -113,9 +113,12 @@ The input centerline is expected to be inside the lumen surface.</string>
            <bool>false</bool>
           </property>
           <property name="removeEnabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="editEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="renameEnabled">
            <bool>true</bool>
           </property>
          </widget>
@@ -166,6 +169,9 @@ The input centerline is expected to be inside the lumen surface.</string>
           <property name="removeEnabled">
            <bool>true</bool>
           </property>
+          <property name="editEnabled">
+           <bool>true</bool>
+          </property>
           <property name="renameEnabled">
            <bool>true</bool>
           </property>
@@ -203,6 +209,9 @@ The input centerline is expected to be inside the lumen surface.</string>
            </stringlist>
           </property>
           <property name="noneEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="editEnabled">
            <bool>true</bool>
           </property>
           <property name="renameEnabled">

--- a/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
+++ b/GuidedArterySegmentation/Resources/UI/GuidedArterySegmentation.ui
@@ -58,7 +58,7 @@ The control points are assumed to be on the contrasted lumen.</string>
          <bool>false</bool>
         </property>
         <property name="removeEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="editEnabled">
          <bool>true</bool>
@@ -132,7 +132,7 @@ If a Shape::Tube node is specified below, this parameter is ignored.</string>
          <bool>true</bool>
         </property>
         <property name="removeEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="editEnabled">
          <bool>true</bool>

--- a/GuidedVeinSegmentation/GuidedVeinSegmentation.py
+++ b/GuidedVeinSegmentation/GuidedVeinSegmentation.py
@@ -254,9 +254,9 @@ class GuidedVeinSegmentationLogic(ScriptedLoadableModuleLogic):
         startTime = time.time()
         logging.info(_("Processing started"))
         
-        # Create slicer.modules.SegmentEditorWidget
-        slicer.modules.segmenteditor.widgetRepresentation()
-        seWidget = slicer.modules.SegmentEditorWidget.editor
+        # Create segment editor object if needed.
+        segmentEditorModuleWidget = slicer.util.getModuleWidget("SegmentEditor")
+        seWidget = segmentEditorModuleWidget.editor
         seWidget.setSegmentationNode(inputSegmentation)
         seWidget.setSourceVolumeNode(inputVolume)
         inputSegmentation.SetReferenceImageGeometryParameterFromVolumeNode(inputVolume)

--- a/QuickArterySegmentation/Resources/UI/QuickArterySegmentation.ui
+++ b/QuickArterySegmentation/Resources/UI/QuickArterySegmentation.ui
@@ -45,7 +45,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <bool>false</bool>
         </property>
         <property name="removeEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="editEnabled">
          <bool>true</bool>
@@ -74,6 +74,12 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
            </stringlist>
           </property>
           <property name="noneEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="editEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="renameEnabled">
            <bool>true</bool>
           </property>
           <property name="SlicerParameterName" stdset="0">
@@ -137,7 +143,7 @@ The fiducial points are assumed to be on the contrasted lumen.</string>
          <bool>true</bool>
         </property>
         <property name="removeEnabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="editEnabled">
          <bool>true</bool>

--- a/StenosisMeasurement2D/Resources/UI/StenosisMeasurement2D.ui
+++ b/StenosisMeasurement2D/Resources/UI/StenosisMeasurement2D.ui
@@ -90,7 +90,7 @@ Clicking at a control point allows to track the slice orientation in the selecte
              <bool>false</bool>
             </property>
             <property name="removeEnabled">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
             <property name="editEnabled">
              <bool>true</bool>

--- a/StenosisMeasurement3D/Resources/UI/qSlicerStenosisMeasurement3DModuleWidget.ui
+++ b/StenosisMeasurement3D/Resources/UI/qSlicerStenosisMeasurement3DModuleWidget.ui
@@ -123,19 +123,6 @@ This should ideally exceed the wall surface a little, and must not be bifurcated
     </layout>
    </item>
    <item>
-    <widget class="QPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>Run the algorithm.</string>
-     </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="ctkCollapsibleButton" name="resultCollapsibleButton">
      <property name="toolTip">
       <string/>
@@ -311,6 +298,19 @@ This should ideally exceed the wall surface a little, and must not be bifurcated
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="applyButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Run the algorithm.</string>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
** GuidedArterySegmentation
Access module widgets directly.
  - slicer.util.getModuleWidget() prepares efficiently the widget representation of
   a module in one call. Use it for the 'Segment editor' and 'Extract
   centerline' modules.
 - Remove irrelevant comment.
 - Show segment in 3D view.
 - Allow deleting nodes in selectors.

** QuickArterySegmentation
Access module widgets directly.
  - slicer.util.getModuleWidget() prepares efficiently the widget representation of
 a module in one call. Use it for the 'Segment editor' and 'Extract
 centerline' modules.
 - Allow deleting and editing nodes in selectors.

** ArterialCalcificationPreProcessor
Improve access to segment editor widget
  - and show result in 3D view by default.

** GuidedVeinSegmentation
Improve access to segment editor widget.

** CrossSectionAnalysis
Improve access to segment editor widget.
 Also:
 - refrain from setting the brush size to fix a hole in a segment since it
 is saved in a scene: use the saved size,
 - allow deleting and editing nodes in selectors.

** BranchClipper
Extend available operations in selectors.

** StenosisMeasurement2D
Extend available operations in selector.

** StenosisMeasurement3D
Use consistent widget layout.
 Place the 'Apply' button at the bottom.
