### PR TITLE
CrossSectionAnalysis: Reset output when input is modified.

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -143,7 +143,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
 
     self.ui.inputCenterlineSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.setInputCenterlineNode)
     self.ui.segmentationSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onInputSegmentationNode)
-    self.ui.segmentSelector.connect("currentSegmentChanged(QString)", self.resetLumenRegions)
+    self.ui.segmentSelector.connect("currentSegmentChanged(QString)", self.onInputSegmentationNode) # Need to perform the same tasks as with segmentationSelector.
     self.ui.outputPlotSeriesSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
     self.ui.outputTableSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.resetOutput)
 
@@ -645,12 +645,14 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         self.ui.inputCenterlineSelector.setCurrentNode(None)
         self.logic.setInputCenterlineNode(None)
         return
+    self.resetOutput()
     # Notes:  updateGUIFromParameterNode() has already done this.
     self.logic.setInputCenterlineNode(centerlineNode)
     self.updatePlotOptions()
     self.updateWallLabelsVisibility()
 
   def onInputSegmentationNode(self):
+    self.resetOutput()
     self.updatePlotOptions()
     self.updateWallLabelsVisibility()
     self.resetLumenRegions()


### PR DESCRIPTION
CrossSectionAnalysis

Previously, the visible output was not invalidated when an input centerline, segmentation or segment was changed in the UI widgets. It was cleared when an output table node or plot series node was changed. The output is now cleared in this situation, the logic being left untouched, though its content is invalid. The changes must be applied again.