### PR TITLE
Fix surface area calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.5)
 
 project(SlicerVMTK)
 

--- a/CrossSectionAnalysis/Logic/vtkCrossSectionCompute.h
+++ b/CrossSectionAnalysis/Logic/vtkCrossSectionCompute.h
@@ -50,7 +50,7 @@ public:
    * The cross-section area and circular equivalent diameter
    * columns of the output table are updated in parallel.
    */
-  void UpdateTable(vtkDoubleArray * crossSectionAreaArray, vtkDoubleArray * ceDiameterArray);
+  bool UpdateTable(vtkDoubleArray * crossSectionAreaArray, vtkDoubleArray * ceDiameterArray);
 
 protected:
   vtkCrossSectionCompute();


### PR DESCRIPTION
1. Fix computation of surface area and more.

The cross-section surface areas were not calculated for model and shape nodes.

At the same time:
 - prefer vtkPolyDataConnectivityFilter to vtkConnectivityFilter
 - stop updating the output table if parallel computing should fail
 - update an erroneous message
 - inform if a cross-section contains holes or branches (although the segment
 does not).

2. Adapt to cmake 4.0.

 - The minimum required version is 3.5.