### PR TITLE
Improve the reliability of cross-sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(SlicerVMTK)
 

--- a/CenterlineDisassembly/CenterlineDisassembly.py
+++ b/CenterlineDisassembly/CenterlineDisassembly.py
@@ -571,14 +571,25 @@ class CenterlineDisassemblyLogic(ScriptedLoadableModuleLogic):
 
         # All cells from the input centerline have been processed.
         if (pointId):
-            newPolyData = vtk.vtkPolyData()
-            newPolyData.SetPoints(points)
-            newPolyData.SetLines(cellArray)
-            newPolyData.GetPointData().AddArray(radiusArray)
+            mergedPolyData = vtk.vtkPolyData()
+            mergedPolyData.SetPoints(points)
+            mergedPolyData.SetLines(cellArray)
+            mergedPolyData.GetPointData().AddArray(radiusArray)
             if masterEdgeArray:
-                newPolyData.GetPointData().AddArray(edgeArray)
+                mergedPolyData.GetPointData().AddArray(edgeArray)
             if masterEdgePCoordArray:
-                newPolyData.GetPointData().AddArray(edgePCoordArray)
+                mergedPolyData.GetPointData().AddArray(edgePCoordArray)
+            """
+            There are 2 pairs of duplicate points.
+            Each pair consists of 2 consecutive point ids with the same coordinate.
+            vtkParallelTransportFrame gives thus 2 invalid tangents of [0, 0, 0].
+            The reason is yet to be found.
+            """
+            cleaner = vtk.vtkCleanPolyData()
+            cleaner.SetInputData(mergedPolyData)
+            cleaner.Update()
+            newPolyData = vtk.vtkPolyData()
+            newPolyData.DeepCopy(cleaner.GetOutput())
 
         return newPolyData
 

--- a/CrossSectionAnalysis/Logic/vtkCrossSectionCompute.h
+++ b/CrossSectionAnalysis/Logic/vtkCrossSectionCompute.h
@@ -15,6 +15,7 @@
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
 #include <vtkObjectFactory.h>
+#include <vtkPlane.h>
 
 /**
  * This class computes cross-section areas
@@ -50,7 +51,20 @@ public:
    * The cross-section area and circular equivalent diameter
    * columns of the output table are updated in parallel.
    */
-  bool UpdateTable(vtkDoubleArray * crossSectionAreaArray, vtkDoubleArray * ceDiameterArray);
+  bool UpdateTable(vtkDoubleArray * crossSectionAreaArray, vtkDoubleArray * ceDiameterArray,
+                   vtkIdList* emptySectionIds  = nullptr);
+
+  /**
+   * Create a cross-section polydata of the input polydata with a given plane.
+   * In ClosestPoint mode, holes nearby to the reference point are rightly
+   * excluded.
+   */
+  enum ExtractionMode{LargestRegion = 0, AllRegions, ClosestPoint};
+  enum SectionCreationResult {Success = 0, Abort, Empty};
+  static SectionCreationResult CreateCrossSection(vtkPolyData * result, vtkPolyData * input,
+                                          vtkPlane * plane,
+                                          ExtractionMode extractionMode = ExtractionMode::ClosestPoint,
+                                          bool fromMainThread = true);
 
 protected:
   vtkCrossSectionCompute();

--- a/Docs/CrossSectionAnalysis.md
+++ b/Docs/CrossSectionAnalysis.md
@@ -34,9 +34,11 @@ If a Shape node (Tube) is used as input, its invisible axial spline is the cente
 
 ### Input centerline
 
-VMTK centerline model and VMTK centerline markups curve have MIS radius scalars attached. Helper functions relative to the maximum inscribed sphere will the be operational.
-
-This input may also be an arbitrary markups curve however. MIS scalars will not be available here.
+This can be
+ - a VMTK centerline model
+ - a VMTK centerline markups curve
+ - an arbitrary markups curve
+ - a Shape::Tune markups node
 
 ### Input surface
 
@@ -61,7 +63,7 @@ A graphical plot of MIS diameter, CE diameter or cross-section area against dist
 - When using a Shape node as a Tube :
     - the Tube should be nicely drawn, avoid kinking in particular,
     - the lumen should be cut to slightly exceed the ends of the Tube, remove all bifurcations and distant parts of the segment that are not enclosed in the Tube.
-- The quality of a segmented lumen is important. It must not contain holes. These may be misleading as the calculated surface area may concern a hole and not the segmented blood. These defects may be identified and tracked in the module. For a segmentation lumen surface, the 'Paint' effect of the 'Segment editor' may be activated in-place to fill the holes. Alternatively, the input segment may be replaced by its largest region.
+- The quality of a segmented lumen is important. It must not contain holes. These may be misleading as the calculated surface area may concern a hole and not the segmented lumen. These defects may be identified and tracked in the module. For a segmentation lumen surface, the 'Paint' effect of the 'Segment editor' may be activated in-place to fill the holes. Alternatively, the input segment may be replaced by its largest region.
 
 |                                                    |                                                    |
 |----------------------------------------------------|----------------------------------------------------|


### PR DESCRIPTION
### Motivation

Avoid creating a cross-section of a hole inside a lumen instead of creating a cross-section of the patent lumen only.

A hole may be the result of a poor quality segmentation. This can be fixed with the 'Regions' option of CrossSectionAnalysis, or by using QuickArterySegmentation or GuidedArterySegmentation modules since the largest region of a segmentation can be selected, consequently discarding any holes inside a lumen.

But holes in a cross-section may originate from the arterial wall as illustrated below (a very unusual case). In very calcified arteries, the common case, the wall will not be a smooth laboratory tube. Calcifications can bulge as 'horns' inside the lumen and the cross-section may have a legitimate hole inside. The result can be completely contrary to expectations.

**In the former technique:**

 - the lumen is cut perpendicular to a centerline
 - the result is one or more islands
 - each island *may* contain holes
 - vtkConnectivityFilter extracts the region closest to the centerline point used to define the cut plane
 - vtkContourTriangulator is then applied to fill the extracted region

The closest region may be the lumen cross-section excluding a hole, or it may be the hole excluding the patent lumen.


**In this technique:**

 - the lumen is cut perpendicular to a centerline
 - the result is one or more islands
 - vtkContourTriangulator is applied to all islands
 - the result is a filled surface in each island remaining independent of each other
 - holes in an island remain as holes
 - vtkPolyDataConnectivityFilter is then applied to extract the island closest to the centerline point used to define the cut plane

The final result is a surface representing the patent lumen.

This facility is implemented in a static function than can be used by other modules, like StenosisMeasurement2D.

#### Illustration

![Cross-section_old-method](https://github.com/user-attachments/assets/e8859ee7-1fd4-43c9-afa1-f33d55676105)

![Cross-section_new-method](https://github.com/user-attachments/assets/34e334d9-a952-4c10-ab78-cf7ab1346f08)

![CE_old-method](https://github.com/user-attachments/assets/f85c716e-fd99-4bc5-b07a-99f7b5ca6615)

![CE_new-method](https://github.com/user-attachments/assets/308761d6-0038-43f6-aff4-d20065f928c6)
