### PR TITLE
Set cmake minimum version consistent with Slicer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
 project(SlicerVMTK)
 


### PR DESCRIPTION
Using 3.16.3...3.19.7.

This was forgotten in #146.