### PR TITLE
Aggregate volumes and more

### DIFF
--- a/Docs/StenosisMeasurement3D.md
+++ b/Docs/StenosisMeasurement3D.md
@@ -34,4 +34,4 @@ Place 2 points of a fidicial node to limit the extent of the study.
      - stenosis degree by volume
      - lesion volume per cm
      - stenosis per cm.
- - A cache of the enclosed lumen is used for faster subsequent processing. It is transparently invalidated on many events. However, Undo/Redo operations, whether in the 'Segment editor' or application-wide, are not detected. In such circumstances, the cache *must* be explicitly cleared, either using the provided menu action or by changing any input node back and forth.
+ - A cache of the enclosed lumen is used for faster subsequent processing. It is transparently invalidated on many events. However, Undo/Redo operations in the 'Segment editor' are not detected. In such circumstances, the cache *must* be explicitly cleared, either using the provided menu action or by changing any input node back and forth. As for the tube, any modified event invalidates the cache.

--- a/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
+++ b/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
@@ -18,6 +18,7 @@
 // StenosisMeasurement3D Logic includes
 #include "vtkSlicerStenosisMeasurement3DLogic.h"
 #include "vtkMRMLStenosisMeasurement3DParameterNode.h"
+#include <vtkMRMLStenosisMeasurement3DLesionModelDisplayNode.h>
 
 // MRML includes
 #include <vtkMRMLScene.h>
@@ -126,6 +127,7 @@ void vtkSlicerStenosisMeasurement3DLogic::RegisterNodes()
   if (this->GetMRMLScene())
   {
     this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLStenosisMeasurement3DParameterNode>::New());
+    this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLStenosisMeasurement3DLesionModelDisplayNode>::New());
   }
 }
 

--- a/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.h
+++ b/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.h
@@ -75,6 +75,9 @@ public:
   bool ClipClosedSurfaceWithClosedOutput(vtkPolyData * input, vtkPolyData * output,
                   double * startOrigin, double * startNormal, double * endOrigin, double * endNormal);
 
+  bool DumpAggregateVolumes(vtkMRMLMarkupsShapeNode * wallShapeNode, vtkPolyData * enclosedSurface,
+                           std::string filepath);
+
 protected:
   vtkSlicerStenosisMeasurement3DLogic();
   ~vtkSlicerStenosisMeasurement3DLogic() override;

--- a/StenosisMeasurement3D/MRML/CMakeLists.txt
+++ b/StenosisMeasurement3D/MRML/CMakeLists.txt
@@ -11,6 +11,8 @@ set(${KIT}_INCLUDE_DIRECTORIES
 set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}ParameterNode.cxx
   vtkMRML${MODULE_NAME}ParameterNode.h
+  vtkMRML${MODULE_NAME}LesionModelDisplayNode.cxx
+  vtkMRML${MODULE_NAME}LesionModelDisplayNode.h
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DLesionModelDisplayNode.cxx
+++ b/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DLesionModelDisplayNode.cxx
@@ -1,0 +1,84 @@
+#include "vtkMRMLStenosisMeasurement3DLesionModelDisplayNode.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkStringArray.h>
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLStenosisMeasurement3DLesionModelDisplayNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::vtkMRMLStenosisMeasurement3DLesionModelDisplayNode()
+{
+  this->HideFromEditors = 1;
+  this->AddToSceneOn();
+  this->RegisteredID = vtkSmartPointer<vtkStringArray>::New();
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::~vtkMRMLStenosisMeasurement3DLesionModelDisplayNode() = default;
+
+//----------------------------------------------------------------------------
+void vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::ReadXMLAttributes(const char** atts)
+{
+  // Read all MRML node attributes from two arrays of names and values
+  int disabledModify = this->StartModify();
+  
+  Superclass::ReadXMLAttributes(atts);
+  
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLEndMacro();
+  
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+  
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyEndMacro();
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::RegisterModel(const char* id)
+{
+  if (this->IsModelRegistered(id))
+  {
+    return false;
+  }
+  this->RegisteredID->InsertNextValue(id);
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::IsModelRegistered(const char* id)
+{
+  for (vtkIdType i = 0; i < this->RegisteredID->GetNumberOfValues(); i++)
+  {
+    if (this->RegisteredID->GetValue(i) == vtkStdString(id))
+    {
+      return true;
+    }
+  }
+  return false;
+}

--- a/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DLesionModelDisplayNode.h
+++ b/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DLesionModelDisplayNode.h
@@ -1,0 +1,49 @@
+#ifndef __vtkmrmlstenosismeasurement3dlesionmodeldisplaynode_h_
+#define __vtkmrmlstenosismeasurement3dlesionmodeldisplaynode_h_
+
+#include "vtkMRML.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLNode.h"
+#include "vtkMRMLModelDisplayNode.h"
+#include "vtkSlicerStenosisMeasurement3DModuleMRMLExport.h"
+
+class vtkStringArray;
+
+/*
+ * The sole purpose of this class is to allow customising the display of the
+ * lesion model from the application startup file. A default node of this type
+ * with all display preferences must be added to the scene for any effect.
+ */
+class VTK_SLICER_STENOSISMEASUREMENT3D_MODULE_MRML_EXPORT vtkMRMLStenosisMeasurement3DLesionModelDisplayNode
+: public vtkMRMLModelDisplayNode
+{
+public:
+  static vtkMRMLStenosisMeasurement3DLesionModelDisplayNode *New();
+  vtkTypeMacro(vtkMRMLStenosisMeasurement3DLesionModelDisplayNode, vtkMRMLModelDisplayNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  
+  vtkMRMLNode* CreateNodeInstance() override;
+  
+  /// Set node attributes from XML attributes
+  void ReadXMLAttributes( const char** atts) override;
+  
+  /// Write this node's information to a MRML file in XML format.
+  void WriteXML(ostream& of, int indent) override;
+  
+  vtkMRMLCopyContentMacro(vtkMRMLStenosisMeasurement3DParameterNode);
+  const char* GetNodeTagName() override {return "LesionModel";}
+
+  bool RegisterModel(const char * id);
+  bool IsModelRegistered(const char * id);
+
+protected:
+  vtkMRMLStenosisMeasurement3DLesionModelDisplayNode();
+  ~vtkMRMLStenosisMeasurement3DLesionModelDisplayNode() override;
+  
+  vtkMRMLStenosisMeasurement3DLesionModelDisplayNode(const vtkMRMLStenosisMeasurement3DLesionModelDisplayNode&);
+  void operator=(const vtkMRMLStenosisMeasurement3DLesionModelDisplayNode&);
+
+  vtkSmartPointer<vtkStringArray> RegisteredID;
+};
+
+#endif // __vtkmrmlstenosismeasurement3dlesionmodeldisplaynode_h_

--- a/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DParameterNode.cxx
+++ b/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DParameterNode.cxx
@@ -37,23 +37,12 @@ vtkMRMLStenosisMeasurement3DParameterNode::vtkMRMLStenosisMeasurement3DParameter
 vtkMRMLStenosisMeasurement3DParameterNode::~vtkMRMLStenosisMeasurement3DParameterNode() = default;
 
 //----------------------------------------------------------------------------
-void vtkMRMLStenosisMeasurement3DParameterNode::SetScene(vtkMRMLScene* scene)
-{
-  Superclass::SetScene(scene);
-  if (scene && !this->GetName())
-  {
-    const std::string name = scene->GenerateUniqueName(this->GetNodeTagName());
-    this->SetName(name.c_str());
-  }
-}
-
-
-//----------------------------------------------------------------------------
 void vtkMRMLStenosisMeasurement3DParameterNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintStdStringMacro(InputSegmentID);
+  vtkMRMLPrintIntMacro(OutputTableRowId);
   vtkMRMLPrintEndMacro();
 }
 
@@ -67,6 +56,7 @@ void vtkMRMLStenosisMeasurement3DParameterNode::ReadXMLAttributes(const char** a
   
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLStringMacro(segmentID, InputSegmentID);
+  vtkMRMLReadXMLIntMacro(tableRowId, OutputTableRowId)
   vtkMRMLReadXMLEndMacro();
   
   this->EndModify(disabledModify);
@@ -78,6 +68,7 @@ void vtkMRMLStenosisMeasurement3DParameterNode::WriteXML(ostream& of, int nInden
   Superclass::WriteXML(of, nIndent);
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLStringMacro(segmentID, InputSegmentID);
+  vtkMRMLWriteXMLIntMacro(tableRowId, OutputTableRowId);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -89,6 +80,7 @@ void vtkMRMLStenosisMeasurement3DParameterNode::CopyContent(vtkMRMLNode* anode, 
   
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyStringMacro(InputSegmentID);
+  vtkMRMLCopyIntMacro(OutputTableRowId);
   vtkMRMLCopyEndMacro();
 }
 

--- a/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DParameterNode.h
+++ b/StenosisMeasurement3D/MRML/vtkMRMLStenosisMeasurement3DParameterNode.h
@@ -21,7 +21,6 @@ public:
     void PrintSelf(ostream& os, vtkIndent indent) override;
     
     vtkMRMLNode* CreateNodeInstance() override;
-    void SetScene(vtkMRMLScene * scene) override;
 
     /// Set node attributes from XML attributes
     void ReadXMLAttributes( const char** atts) override;
@@ -30,7 +29,7 @@ public:
     void WriteXML(ostream& of, int indent) override;
     
     vtkMRMLCopyContentMacro(vtkMRMLStenosisMeasurement3DParameterNode);
-    const char* GetNodeTagName() override {return "Parameter set";}
+    const char* GetNodeTagName() override {return "Study";}
 
     void SetInputShapeNodeID(const char *nodeID);
     const char *GetInputShapeNodeID();

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
@@ -725,7 +725,8 @@ qSlicerStenosisMeasurement3DModuleWidget::createEnclosedSurface(vtkMRMLMarkupsSh
   }
   if (enclosingType == vtkSlicerStenosisMeasurement3DLogic::Distinct)
   {
-    std::cerr << "Input tube and input lumen do not intersect." << std::endl;
+    // They don't intersect or vtkBooleanOperationPolyDataFilter could not handle them.
+    std::cerr << "Input tube and input lumen could not be intersected." << std::endl;
     return enclosingType;
   }
   enclosedSurface->Initialize();
@@ -764,7 +765,8 @@ bool qSlicerStenosisMeasurement3DModuleWidget::getEnclosedSurface(vtkMRMLMarkups
     }
     if (enclosingType == vtkSlicerStenosisMeasurement3DLogic::Distinct)
     {
-      this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Input tube and input lumen do not intersect."), 5000);
+      // They don't intersect or vtkBooleanOperationPolyDataFilter could not handle them.
+      this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Error: input tube and input lumen could not be intersected."), 5000);
       return false;
     }
     // The caller must cache the enclosed surface.

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
@@ -44,6 +44,7 @@
 #include <vtkMRMLSelectionNode.h>
 #include <vtkMRMLUnitNode.h>
 #include <vtkMRMLStenosisMeasurement3DParameterNode.h>
+#include <vtkMRMLStenosisMeasurement3DLesionModelDisplayNode.h>
 #include <qSlicerExtensionsManagerModel.h>
 
 //-----------------------------------------------------------------------------
@@ -383,6 +384,23 @@ void qSlicerStenosisMeasurement3DModuleWidget::createLesionModel(vtkMRMLMarkupsS
                           lesion);
   model->CreateDefaultDisplayNodes();
   model->SetAndObserveMesh(lesion);
+
+  vtkMRMLNode * defaultNode = this->mrmlScene()->GetDefaultNodeByClass("vtkMRMLStenosisMeasurement3DLesionModelDisplayNode");
+  if (!defaultNode)
+  {
+    return;
+  }
+  vtkMRMLStenosisMeasurement3DLesionModelDisplayNode * defaultDisplayNode
+    = vtkMRMLStenosisMeasurement3DLesionModelDisplayNode::SafeDownCast(defaultNode);
+  if (!defaultDisplayNode)
+  {
+    return;
+  }
+  // Apply the template display node once only to keep any user modifications after creation.
+  if (model->GetDisplayNode() && defaultDisplayNode->RegisterModel(model->GetID()))
+  {
+    model->GetDisplayNode()->CopyContent(defaultDisplayNode);
+  }
 }
 
 //-------------------------- From util.py -------------------------------------

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
@@ -557,7 +557,7 @@ void qSlicerStenosisMeasurement3DModuleWidget::onSegmentationRepresentationModif
 void qSlicerStenosisMeasurement3DModuleWidget::onFiducialNodeChanged(vtkMRMLNode * node)
 {
   Q_D(qSlicerStenosisMeasurement3DModuleWidget);
-  if (!d->parameterNode || (d->parameterNode->GetInputFiducialNode() == node))
+  if (!d->parameterNode)
   {
     return;
   }
@@ -580,10 +580,6 @@ void qSlicerStenosisMeasurement3DModuleWidget::onFiducialNodeChanged(vtkMRMLNode
     this->logic->UpdateBoundaryControlPointPosition(0, fiducialNode, shapeNode);
     this->logic->UpdateBoundaryControlPointPosition(1, fiducialNode, shapeNode);
   }
-  if (d->parameterNode)
-  {
-    d->parameterNode->SetInputFiducialNodeID(node ? node->GetID() : nullptr);
-  }
   this->clearLumenCache();
 }
 
@@ -591,7 +587,7 @@ void qSlicerStenosisMeasurement3DModuleWidget::onFiducialNodeChanged(vtkMRMLNode
 void qSlicerStenosisMeasurement3DModuleWidget::onShapeNodeChanged(vtkMRMLNode * node)
 {
   Q_D(qSlicerStenosisMeasurement3DModuleWidget);
-  if (!d->parameterNode || (d->parameterNode->GetInputShapeNode() == node))
+  if (!d->parameterNode)
   {
     return;
   }
@@ -615,10 +611,6 @@ void qSlicerStenosisMeasurement3DModuleWidget::onShapeNodeChanged(vtkMRMLNode * 
   {
     this->logic->UpdateBoundaryControlPointPosition(0, fiducialNode, shapeNode);
     this->logic->UpdateBoundaryControlPointPosition(1, fiducialNode, shapeNode);
-  }
-  if (d->parameterNode)
-  {
-    d->parameterNode->SetInputShapeNodeID(node ? node->GetID() : nullptr);
   }
   this->clearLumenCache();
 }

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
@@ -87,8 +87,9 @@ protected:
   static void onFiducialPointEndInteraction(vtkObject *caller,
                                             unsigned long event, void *clientData, void *callData);
 
-  vtkSmartPointer<vtkCallbackCommand> tubeObservation;
-  static void onTubePointEndInteraction(vtkObject *caller,
+  vtkSmartPointer<vtkCallbackCommand> tubePointEndInteractionObservation;
+  vtkSmartPointer<vtkCallbackCommand> tubeModifiedObservation;
+  static void onTubeModified(vtkObject *caller,
                                         unsigned long event, void *clientData, void *callData);
 
   vtkSmartPointer<vtkCallbackCommand> segmentationRepresentationObservation;

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
@@ -63,6 +63,7 @@ protected slots:
   void onParameterNodeAddedByUser(vtkMRMLNode * node);
   void onParameterNodeChanged(vtkMRMLNode * node);
   void clearLumenCache();
+  void dumpAggregateVolumes();
 
 protected:
   QScopedPointer<qSlicerStenosisMeasurement3DModuleWidgetPrivate> d_ptr;
@@ -96,6 +97,7 @@ protected:
 
   void setDefaultParameters(vtkMRMLNode * node);
   void updateGuiFromParameterNode();
+  void addMenu();
 
 private:
   Q_DECLARE_PRIVATE(qSlicerStenosisMeasurement3DModuleWidget);


### PR DESCRIPTION
StenosisMeasurement3D

 - Dump aggregate volumes in a database.
  An SQLite database is created to store aggregate volumes of the whole enclosed
  lumen and of the tube. These indexed tables are created:
  \- CummulativeVolumes: cummulates measurements from the first spline point to
  the last with a unit spline point step
  \- BoundVolumes: provide measurements within spline point bounds, from point id
  'p' to 'p+n'.

 - Invalidate the enclosed lumen cache on any modified event of the tube.

 - Improve the parameter node class.

 - Secure boolean operation handling on inputs.
  The largest region of the polydata is transparently extracted and cleaned
  for each input before the boolean operation to prevent application crash.

 - Ensure the tube and fiducial nodes are rightly observed when loading a saved
  scene.

 - Add a display node for the lesion model to allow customising its appearance via a default scene node.