### PR TITLE
CrossSectionAnalysis - a few improvements

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -717,13 +717,13 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         self.logic.inputCenterlineNode
         and self.logic.inputCenterlineNode.IsTypeOf("vtkMRMLMarkupsShapeNode")
         and self.logic.lumenSurfaceNode):
-      self.logic.showStatusMessage(_(("Invalid centerline or lumen surface: cannot clip the lumen.",)))
+      self.logic.showStatusMessage((_("Invalid centerline or lumen surface: cannot clip the lumen."),))
       return
 
     with slicer.util.tryWithErrorDisplay(_("Failed to clip lumen in tube."), waitCursor=True):
       clippedLumen = vtk.vtkPolyData()
       if not self.logic.clipLumenInTube(clippedLumen):
-        self.logic.showStatusMessage(_(("Failed to clip the lumen inside the tube.",)))
+        self.logic.showStatusMessage((_("Failed to clip the lumen inside the tube."),))
         return
 
       clippedLumenName = slicer.mrmlScene.GenerateUniqueName("Clipped lumen")
@@ -1620,7 +1620,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     clipped = sm3Logic.GetClosedSurfaceEnclosingType(
                   tubeSurface, lumenSurface, clippedLumenRaw)
     if (clipped == sm3Logic.Distinct) or (clipped == sm3Logic.EnclosingType_Last):
-      return False
+      raise RuntimeError(_("The input wall surface and the input lumen surfaces could not be intersected."))
     else:
       # Clip any excess from vtkBooleanOperationPolyDataFilter at each end.
       # If the lumen is a loop, the result may be curious.
@@ -1645,11 +1645,9 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
         if not sm3Logic.UpdateClosedSurfaceMesh(clippedLumenFixed, clippedSurface):
           clippedSurface.Initialize()
           clippedSurface.DeepCopy(clippedLumenFixed)
-          return False
       else:
         clippedSurface.Initialize()
         clippedSurface.DeepCopy(clippedLumenRaw)
-        return False
 
     return True
 
@@ -1836,7 +1834,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     numberOfIds = ids.GetNumberOfIds()
     if numberOfIds == 0:
       return
-    statusMessage = str(numberOfIds) + " " + _("empty sections have been detected; consider improving the input lumen {nameOfSurface}." ).format(nameOfSurface=surfaceName)
+    statusMessage = str(numberOfIds) + " " + _("empty sections have been detected; consider improving the input surface {nameOfSurface}." ).format(nameOfSurface=surfaceName)
     consoleMessage = "Empty sections have been created at these point ids of the centerline: "
     idList = ""
     sorter = vtk.vtkSortDataArray()
@@ -1844,7 +1842,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     for i in range(numberOfIds):
       idList = idList + ", " + str(ids.GetId(i))
     idList = idList[2 : len(idList)]
-    consoleMessage = consoleMessage + idList + "; consider improving the input lumen (" + surfaceName +")."
+    consoleMessage = consoleMessage + idList + "; consider improving the input surface (" + surfaceName +")."
     self.showStatusMessage((statusMessage,))
     logging.warning(consoleMessage)
 

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -319,19 +319,6 @@ The input centerline is expected to be inside the lumen surface.</string>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="outputPlotSeriesTypeComboBox">
-          <property name="toolTip">
-           <string>Select the plot's Y axis</string>
-          </property>
-          <property name="currentIndex">
-           <number>-1</number>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QToolButton" name="togglePlotLayoutButton">
           <property name="toolTip">
            <string>Toggle between the plot layout and the previous one.</string>
@@ -343,7 +330,7 @@ The input centerline is expected to be inside the lumen surface.</string>
         </item>
        </layout>
       </item>
-      <item row="6" column="0" colspan="2">
+      <item row="7" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="optionsCollapsibleGroupBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -581,7 +568,7 @@ The 'Sphere' brush is enforced. Further customisation can be performed in the 'S
         </layout>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
        <widget class="QPushButton" name="applyButton">
         <property name="enabled">
          <bool>false</bool>
@@ -591,6 +578,25 @@ The 'Sphere' brush is enforced. Further customisation can be performed in the 'S
         </property>
         <property name="text">
          <string>Apply</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="outputPlotSeriesTypeComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Select the plot's Y axis</string>
+        </property>
+        <property name="currentIndex">
+         <number>-1</number>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
CrossSectionAnalysis

    - Fix badly initialised string arrays
    - Raise a runtime error if clipping fails
    - Don't return if the clipped lumen could not be fixed
    - Improve the scope of some messages
    - Move the plot series type combobox below the plot output selector to reduce the
    width of the module's widget. This is more appropriate on laptop screen.