### PR TITLE
Improving clipping the lumen inside a tube (mainly)

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -205,8 +205,9 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.updatePlotChartView(parameterNode)
     self.resetOutput()
     if parameterNode.HasParameter(ROLE_INITIALIZED):
-      self.onApply(True)
-      self.ui.moveToPointSliderWidget.setValue(float(pointIndex))
+      if parameterNode.GetNodeReference(ROLE_INPUT_CENTERLINE):
+        self.onApply(True)
+    self.ui.moveToPointSliderWidget.setValue(float(pointIndex))
 
   def cleanup(self):
     """
@@ -398,7 +399,6 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
 
   def onApply(self, replay = False):
     with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
-
       if not self.logic.isInputCenterlineValid():
         raise ValueError(_("Input is invalid."))
 

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -1047,7 +1047,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
   # Identify the regions of the input lumen based on polydata connectivity.
   def getRegionsOfLumenSurface(self):
     closedSurfacePolyData = vtk.vtkPolyData()
-    self.getClosedSurfacePolyData(closedSurfacePolyData)
+    self.getLumenClosedSurfacePolyData(closedSurfacePolyData)
     if (closedSurfacePolyData.GetNumberOfPoints() == 0):
       logging.error(_("Invalid surface polydata."))
       return
@@ -1610,7 +1610,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     if not self.inputCenterlineNode.IsTypeOf("vtkMRMLMarkupsShapeNode"):
       raise ValueError(_("Input centerline node is not a Shape node."))
     lumenSurface = vtk.vtkPolyData()
-    self.getClosedSurfacePolyData(lumenSurface)
+    self.getLumenClosedSurfacePolyData(lumenSurface)
     if lumenSurface.GetNumberOfPoints() == 0:
       raise ValueError(_("Empty lumen surface retrieved."))
     tubeSurface = self.inputCenterlineNode.GetCappedTubeWorld()
@@ -1651,7 +1651,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
 
     return True
 
-  def getClosedSurfacePolyData(self, closedSurfacePolyData):
+  def getLumenClosedSurfacePolyData(self, closedSurfacePolyData):
     if (not self.lumenSurfaceNode):
       logging.error(_("Lumen surface node is not set."))
       return
@@ -1676,7 +1676,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     plane.SetNormal(normal)
 
     closedSurfacePolyData = vtk.vtkPolyData()
-    self.getClosedSurfacePolyData(closedSurfacePolyData)
+    self.getLumenClosedSurfacePolyData(closedSurfacePolyData)
 
     # If segmentation is transformed, apply it to the cross-section model. All computations are performed in the world coordinate system.
     if self.lumenSurfaceNode.GetParentTransformNode():

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -277,11 +277,11 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.ui.browseCollapsibleButton.collapsed = True
 
   def updatePlotChartNode(self, parameterNode):
-    plotChartNode = parameterNode.GetNodeReference("PlotChartNode")
+    plotChartNode = parameterNode.GetNodeReference(ROLE_OUTPUT_PLOT_CHART_NODE)
     if not plotChartNode:
       plotChartNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotChartNode")
       plotChartNode.SetName(parameterNode.GetName()) # Name in the parameter set combobox.
-      parameterNode.SetNodeReferenceID("PlotChartNode", plotChartNode.GetID())
+      parameterNode.SetNodeReferenceID(ROLE_OUTPUT_PLOT_CHART_NODE, plotChartNode.GetID())
     self.logic.plotChartNode = plotChartNode
 
   def updatePlotChartView(self, parameterNode = None):
@@ -1891,6 +1891,7 @@ ROLE_INPUT_CENTERLINE = "InputCenterline"
 ROLE_INPUT_SEGMENTATION = "InputSegmentation"
 ROLE_INPUT_SEGMENT_ID = "InputSegment"
 ROLE_OUTPUT_TABLE = "OutputTable"
+ROLE_OUTPUT_PLOT_CHART_NODE = "OutputPlotChartNode"
 ROLE_OUTPUT_PLOT_SERIES = "OutputPlotSeries"
 ROLE_AXIAL_SLICE_NODE = "AxialSliceNode"
 ROLE_LONGITUDINAL_SLICE_NODE = "LongitudinalSliceNode"

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -213,7 +213,9 @@ The input centerline is expected to be inside the lumen surface.</string>
           <item>
            <widget class="QToolButton" name="clipLumenToolButton">
             <property name="toolTip">
-             <string>Clip the lumen inside the tube. A new segment or a new model is generated.</string>
+             <string>Clip the lumen inside the tube. A new segment or a new model is generated.
+
+There may be artifacts at the ends of the tube, or in the midst of a loop or arch. These should be manually fixed if necessary.</string>
             </property>
             <property name="text">
              <string>...</string>

--- a/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
+++ b/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
@@ -602,31 +602,24 @@ vtkSlicerStenosisMeasurement3DLogic::GetClosedSurfaceEnclosingType(vtkPolyData* 
   triangulatorFirst->SetInputData(first);
   triangulatorFirst->Update();
 
-  /*
-   * Using the largest region prevents crashes when there are holes in the
-   * segment. A segment with a detached largest region outside of the tube is
-   * considered out of purpose for the module.
-   */
-  vtkNew<vtkPolyDataConnectivityFilter> regionExtractorFirst;
-  regionExtractorFirst->SetExtractionModeToLargestRegion();
-  regionExtractorFirst->SetInputConnection(triangulatorFirst->GetOutputPort());
-  regionExtractorFirst->Update();
-
   vtkNew<vtkTriangleFilter> triangulatorSecond;
   triangulatorSecond->SetInputData(second);
   triangulatorSecond->Update();
 
-  vtkNew<vtkPolyDataConnectivityFilter> regionExtractorSecond;
-  regionExtractorSecond->SetExtractionModeToLargestRegion();
-  regionExtractorSecond->SetInputConnection(triangulatorSecond->GetOutputPort());
-  regionExtractorSecond->Update();
-
+  /*
+   * Cleaning is seen sufficient to prevent crashes when there are holes in the
+   * segment.
+   * The largest region was previously used, but this generates too many
+   * artifacts at the ends or in an arch. A segment with a detached largest 
+   * region outside of the tube is considered out of purpose for the module.
+   */
+  
   vtkNew<vtkCleanPolyData> cleanerFirst;
-  cleanerFirst->SetInputConnection(regionExtractorFirst->GetOutputPort());
+  cleanerFirst->SetInputConnection(triangulatorFirst->GetOutputPort());
   cleanerFirst->Update();
 
   vtkNew<vtkCleanPolyData> cleanerSecond;
-  cleanerSecond->SetInputConnection(regionExtractorSecond->GetOutputPort());
+  cleanerSecond->SetInputConnection(triangulatorSecond->GetOutputPort());
   cleanerSecond->Update();
 
   {


### PR DESCRIPTION
commit eaa2dab
    Check if an input centerline is referenced in the parameter node.
    
    CrossSectionAnalysis
    
    Before updating the widget when a parameter set is changed.

commit bbd59d3
    Rename function to be more meaningful.
    
    CrossSectionAnalysis
    
     getClosedSurfacePolyData() -> getLumenClosedSurfacePolyData()

commit 22fe12a
    Reference the plot chart node in the parameter node with a constant.
    
    CrossSectionAnalysis

commit 889e788
    Improve intersecting the surfaces.
    
    StenosisMeasurement3D
    
    The largest regions were previously used, but this generates too many
    artifacts at the ends or in an arch. Moreover, little or no clipping were
    observed.
    
    Cleaning is seen sufficient to prevent crashes when there are holes in the
    segment.

commit 65276d9
    Use the enclosed polydata in the lumen as it is clipped.
    
    CrossSectionAnalysis
    
    Artifacts often exist at the ends of the clipped polydata. These were previously
    removed by cutting the clipped lumen at each end of the tube. This is not
    friendly to archs and loops.
    
    Use the clipped lumen as it is and inform about artifacts to be manually
    removed if necessary.
