### PR TITLE
Update VMTK tag for vtkAddon wrapper files.

### DIFF
--- a/SuperBuild/External_VMTK.cmake
+++ b/SuperBuild/External_VMTK.cmake
@@ -55,7 +55,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   if(${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR} VERSION_GREATER_EQUAL 5.1)
     # Slicer >= 5.1 uses recent ITK-5.3RC version, which has BooleanStdVectorType
     # (see https://github.com/InsightSoftwareConsortium/ITK/commit/bc9ba8540f96c0fa4e9100b25b05eb812074a64e)
-    set(DEFAULT_VMTK_TAG a95f3e3c6654fa0e8c029615a6f518897d618a01)
+    set(DEFAULT_VMTK_TAG 4179a77eeaf0b57644892143a3ed401984c49b80)
   else()
     # Slicer < 5.1 uses older ITK-5.3RC version, which does not yet have BooleanStdVectorType
     set(DEFAULT_VMTK_TAG 30b0fdad5674d6f134e8a8b601bcef7917671b0a)


### PR DESCRIPTION
Python wrapper files in vtkAddon have been updated for VTK 9.5.

Updated files in vtkAddon:

vtkMacroKitPythonWrap.cmake
vtkWrapHierarchy.cmake
vtkWrapPython.cmake.