### PR TITLE
Improve CrossSectionAnalysis mainly

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -359,8 +359,12 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.ui.axialSliceHorizontalFlipCheckBox.setChecked(self.logic.axialSliceHorizontalFlip)
     self.ui.axialSliceVerticalFlipCheckBox.setChecked(self.logic.axialSliceVerticalFlip)
 
-    itemIndex = self.ui.outputPlotSeriesTypeComboBox.findData(self._parameterNode.GetParameter(ROLE_OUTPUT_PLOT_SERIES_TYPE))
-    self.ui.outputPlotSeriesTypeComboBox.setCurrentIndex(itemIndex)
+    plotSeriesTypeComboBox = self.ui.outputPlotSeriesTypeComboBox
+    itemIndex = plotSeriesTypeComboBox.findData(self._parameterNode.GetParameter(ROLE_OUTPUT_PLOT_SERIES_TYPE))
+    if itemIndex < 0:
+      itemIndex = 0
+    plotSeriesTypeComboBox.setCurrentIndex(itemIndex)
+    self.logic.setPlotSeriesType(plotSeriesTypeComboBox.currentData)
 
     # Update button states
 
@@ -681,7 +685,9 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.updateUIWithMetrics(value)
 
   def setPlotSeriesType(self, type):
+    wasBlocked = self.ui.outputPlotSeriesTypeComboBox.blockSignals(True)
     self.setValueInParameterNode(ROLE_OUTPUT_PLOT_SERIES_TYPE, self.ui.outputPlotSeriesTypeComboBox.currentData)
+    self.ui.outputPlotSeriesTypeComboBox.blockSignals(wasBlocked)
     self.logic.setPlotSeriesType(self.ui.outputPlotSeriesTypeComboBox.currentData)
 
   def setHorizontalFlip(self):
@@ -744,7 +750,8 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     if self._parameterNode:
       itemIndex = self.ui.outputPlotSeriesTypeComboBox.findData(self._parameterNode.GetParameter("OutputPlotSeriesType"))
       if itemIndex > -1:
-        self.ui.outputPlotSeriesTypeComboBox.setCurrentIndex(itemIndex)
+        comboBox.setCurrentIndex(itemIndex)
+    self.logic.setPlotSeriesType(comboBox.currentData)
 
   def updateClipButtonVisibility(self):
     self.ui.clipLumenToolButton.setVisible(

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -404,6 +404,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     if not self.ui.outputTableSelector.currentNode():
       outputTableNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
       self.ui.outputTableSelector.setCurrentNode(outputTableNode)
+    self.ui.outputTableSelector.currentNode().SetUseColumnTitleAsColumnHeader(True)
     if not self.ui.outputPlotSeriesSelector.currentNode():
       outputPlotSeriesNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotSeriesNode")
       self.ui.outputPlotSeriesSelector.setCurrentNode(outputPlotSeriesNode)

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -1059,7 +1059,7 @@ Concerns orthogonal reformat in axial navigation.</string>
           <item>
            <widget class="QToolButton" name="showMISDiameterButton">
             <property name="toolTip">
-             <string>Show the maximum inscribed sphere diameter.</string>
+             <string>Show the maximum inscribed sphere.</string>
             </property>
             <property name="text">
              <string>show</string>
@@ -1122,7 +1122,7 @@ Concerns orthogonal reformat in axial navigation.</string>
              <bool>false</bool>
             </property>
             <property name="toolTip">
-             <string>Show cross-section at current point. Requires input lumen surface.</string>
+             <string>Show the cross-section of an input lumen surface.</string>
             </property>
             <property name="text">
              <string>show</string>
@@ -1366,6 +1366,22 @@ Caution: values at bifurcations may not have clinical meaning.</string>
             <widget class="QToolButton" name="maxWallSurfaceAreaButton">
              <property name="text">
               <string>max</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="showWallCrossSectionButton">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="toolTip">
+              <string>Show the cross-section of an input wall surface.</string>
+             </property>
+             <property name="text">
+              <string>show</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
              </property>
             </widget>
            </item>

--- a/Docs/CrossSectionAnalysis.md
+++ b/Docs/CrossSectionAnalysis.md
@@ -8,11 +8,13 @@ Main features:
 - orthogonal slice view reformat
 - spin the slice view by an arbitrary amount
 - define an arbitrary centerline point as origin
-- go to defined origin
-- go to minimum and maximum MIS diameter
-- go to minimum and maximum cross-section area
+- go to a defined origin
+- go to the minimum and the maximum MIS diameter
+- go to the minimum and the maximum cross-section area
 - show the maximum inscribed sphere
-- show the cross-section
+- show the cross-section of the lumen
+- show the cross-section of a Tube
+- clip a lumen inside a Tube.
 
 Computed metrics:
 
@@ -38,7 +40,7 @@ This can be
  - a VMTK centerline model
  - a VMTK centerline markups curve
  - an arbitrary markups curve
- - a Shape::Tune markups node
+ - a Shape::Tube markups node
 
 ### Input surface
 
@@ -56,13 +58,14 @@ A graphical plot of MIS diameter, CE diameter or cross-section area against dist
 
 - The parameter set node is intended for distinct combinations of centerlines and surfaces to isolate a study.
 - Point coordinates can be displayed as an array in a single column, or split in three distinct columns. One can choose between RAS or LPS coordinates.
-- A markups curve may also lie outside a surface.
 - Providing a surface (segmentation or model) is optional. For example, a markups curve may be drawn on a vascular structure's boundary in slice views, to see the corresponding cross-sections only.
 - The meaning of a surface area is subject to its requirement. For tubular surfaces for instance, orthogonal section is a requirement.
 - Reslicing can be performed as cross-section along the centerline, or in orthogonal planes at each centerline point (adjusted with the 'Spin' slider).
 - When using a Shape node as a Tube :
     - the Tube should be nicely drawn, avoid kinking in particular,
-    - the lumen should be cut to slightly exceed the ends of the Tube, remove all bifurcations and distant parts of the segment that are not enclosed in the Tube.
+    - the [Edit centerline](https://github.com/vmtk/SlicerExtension-VMTK/blob/master/Docs/EditCenterline.md) module may be helpful to *pre-define* a Tube,
+    - the lumen should be cut to slightly exceed the ends of the Tube, remove all bifurcations and distant parts of the segment that are not enclosed in the Tube,
+    - alternatively, the lumen can be clipped inside the Tube.
 - The quality of a segmented lumen is important. It must not contain holes. These may be misleading as the calculated surface area may concern a hole and not the segmented lumen. These defects may be identified and tracked in the module. For a segmentation lumen surface, the 'Paint' effect of the 'Segment editor' may be activated in-place to fill the holes. Alternatively, the input segment may be replaced by its largest region.
 
 |                                                    |                                                    |

--- a/Docs/StenosisMeasurement3D.md
+++ b/Docs/StenosisMeasurement3D.md
@@ -4,21 +4,17 @@ This [Slicer](https://www.slicer.org/) module calculates arterial stenosis degre
 
 **Usage**
 
-Segment a diseased arterial lumen using the segment editor. Draw a best fit arterial wall around the lumen using the Tube (Shape) markups. This is not a computed step, but totally observer dependent. It is more accurately done in slice views in these ways:
+Segment a diseased arterial lumen using the segment editor. Draw a best fit arterial wall around the lumen using the Tube (Shape) markups. This is not a computed step, but totally observer dependent.
 
- - proceed with many manual reformatting so as to be perpendicular to the arterial axis prior to placing a pair of points in one slice view (activate 'Slice intersections', use 'Ctrl+Alt+LeftClickDrag' and/or 'Interaction'),
- 
- - use a temporary open curve markups node: place each point of the curve at best estimates of the artery's anatomical axis; use 'Cross-section analysis' module to browse a resliced view along the curve; place pairs of control points of the Shape::Tube node at significant intervals during browsing; the open curve node can then be hidden or removed;
- 
- - place pairs of control points of the Shape::Tube in a 'Volume rendering' view along the artery, click on successive control points and reslice to the active control point each time in the Markups module widget; this will reslice the selected view such that both elements of a pair of control points of the Shape::Tube node can be repositioned accurately to the best estimate of the artery's walls;
+ - Point placement of a Tube can be manually performed in different ways, refer to some [helper videos](https://github.com/chir-set/SlicerExtraMarkups/blob/main/Shape/README.md) in the 'Tube' section of this page.
 
- - use '[Edit centerline](https://github.com/vmtk/SlicerExtension-VMTK/blob/master/Docs/EditCenterline.md)' module.
+ - Alternatively, use the '[Edit centerline](https://github.com/vmtk/SlicerExtension-VMTK/blob/master/Docs/EditCenterline.md)' module to *pre-define* a Tube.
 
-Place 2 points of a fidicial node to limit the extent of the study.
+Place 2 points of a fiducial node to limit the extent of the study.
 
 **Options**
 
- - Show a model of the surfaces being cut down and measured.
+ - Show a model of the lesion.
  - Store the results in a table
 
 


### PR DESCRIPTION
Show a cross-section model of a tube.
CrossSectionAnalysis

If a Shape::Tube node is used as an input centerline, a cross-section model of
the tube can be here optionally created. This may improve the visual impression
of a tight stenosis in particular, when shown together with the cross-section
model of the lumen.

At the same time, improve a few UI strings and the documentation page.
\----------------------------
Update documentation.
StenosisMeasurement3D
\----------------------------
Ensure that a plot series type is selected.
CrossSectionAnalysis

Ensure that the plot series type combobox has a current item whenever an input
or output node changes and update the logic accordingly.
\----------------------------
Use the column titles as headers of the output table.
CrossSectionAnalysis
\----------------------------
