### PR TITLE
Improve clipping a segment in a tube

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -1738,11 +1738,6 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
                   tubeSurface, lumenSurface, clippedLumenRaw)
     if (clipped == sm3Logic.Distinct) or (clipped == sm3Logic.EnclosingType_Last):
       raise RuntimeError(_("The input wall surface and the input lumen surfaces could not be intersected."))
-    else:
-      # Remesh the polydata using a segmentation. (Even for an input model.)
-      if not sm3Logic.UpdateClosedSurfaceMesh(clippedLumenRaw, clippedSurface):
-        clippedSurface.Initialize()
-        clippedSurface.DeepCopy(clippedLumenRaw)
 
     return True
 

--- a/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
+++ b/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
@@ -699,36 +699,6 @@ vtkSlicerStenosisMeasurement3DLogic::GetClosedSurfaceEnclosingType(vtkPolyData* 
   return EnclosingType::Distinct;
 }
 
-//-----------------------------------------------------------------------------
-// Obtain a very nice mesh as seen in WireFrame representation.
-bool vtkSlicerStenosisMeasurement3DLogic::UpdateClosedSurfaceMesh(vtkPolyData* inMesh, vtkPolyData* outMesh)
-{
-  if (!inMesh || !outMesh)
-  {
-    vtkErrorMacro("Parameter 'inMesh' or 'outMesh' is NULL.");
-    return false;
-  }
-  if (!this->GetMRMLScene())
-  {
-    vtkErrorMacro("MRML scene is NULL.");
-    return false;
-  }
-
-  vtkNew<vtkMRMLSegmentationNode> segmentationNode;
-  segmentationNode->CreateClosedSurfaceRepresentation();
-
-  const std::string preferred3DRepresentationName = vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName();
-
-  const std::string segmentId = segmentationNode->AddSegmentFromClosedSurfaceRepresentation(inMesh, this->GetMRMLScene()->GenerateUniqueName("MeshInput"));
-  // The mesh is recreated here.
-  outMesh->Initialize();
-  segmentationNode->GetSegmentation()->RemoveRepresentation(preferred3DRepresentationName);
-  segmentationNode->GetSegmentation()->CreateRepresentation(preferred3DRepresentationName);
-  segmentationNode->GetClosedSurfaceRepresentation(segmentId, outMesh);
-
-  return true;
-}
-
 //---------------------------------------------------------------------------
 bool vtkSlicerStenosisMeasurement3DLogic::CreateLesion(vtkMRMLMarkupsShapeNode * wallShapeNode,
                                                        vtkPolyData * enclosedSurface,
@@ -1211,7 +1181,6 @@ bool vtkSlicerStenosisMeasurement3DLogic::UpdateSegmentBySmoothClosing(vtkMRMLSe
 
   return true;
 }
-
 
 //------------------------------------------------------------------------------
 VolumeComputeWorker::VolumeComputeWorker()

--- a/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.h
+++ b/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.h
@@ -69,7 +69,6 @@ public:
   // Both input surfaces *must* be closed. This may be time consuming.
   EnclosingType GetClosedSurfaceEnclosingType(vtkPolyData * first, vtkPolyData * second, vtkPolyData * enclosed = nullptr);
 
-  bool UpdateClosedSurfaceMesh(vtkPolyData * inMesh, vtkPolyData * outMesh);
   // Cut the input using a plane; either part may be in output. Create open polydata for display.
   bool ClipClosedSurface(vtkPolyData * input, vtkPolyData * output,
             double * origin, double * normal, bool clipped = false);

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
@@ -248,7 +248,7 @@ void qSlicerStenosisMeasurement3DModuleWidget::onApply()
 
   // Get the lumen enclosed in the tube once only, it may be time consuming.
   vtkNew<vtkPolyData> enclosedSurface;
-  if (!this->getEnclosedSurface(shapeNodeReal, segmentationNodeReal, currentSegmentID, enclosedSurface, true))
+  if (!this->getEnclosedSurface(shapeNodeReal, segmentationNodeReal, currentSegmentID, enclosedSurface))
   {
     return;
   }
@@ -706,8 +706,7 @@ void qSlicerStenosisMeasurement3DModuleWidget::onUpdateBoundary(int index)
 vtkSlicerStenosisMeasurement3DLogic::EnclosingType
 qSlicerStenosisMeasurement3DModuleWidget::createEnclosedSurface(vtkMRMLMarkupsShapeNode * wallShapeNode,
                                                                 vtkMRMLSegmentationNode * lumenSegmentationNode,
-                                                                std::string segmentID, vtkPolyData * enclosedSurface,
-                                                                bool updateMesh)
+                                                                std::string segmentID, vtkPolyData * enclosedSurface)
 {
   if (!wallShapeNode || !lumenSegmentationNode || !enclosedSurface)
   {
@@ -748,21 +747,13 @@ qSlicerStenosisMeasurement3DModuleWidget::createEnclosedSurface(vtkMRMLMarkupsSh
   enclosedSurface->Initialize();
   enclosedSurface->DeepCopy(inputLumenEnclosed);
 
-  if (updateMesh)
-  {
-    // enclosedSurface is Initialize()d there and is not modified on abort.
-    if (!this->logic->UpdateClosedSurfaceMesh(inputLumenEnclosed, enclosedSurface))
-    {
-      std::cerr << "Error updating the clipped lumen; continuing with the raw clipped surface." << endl;
-    }
-  }
   return enclosingType;
 }
 
 //-----------------------------------------------------------------------------
 bool qSlicerStenosisMeasurement3DModuleWidget::getEnclosedSurface(vtkMRMLMarkupsShapeNode * wallShapeNode,
                                                                   vtkMRMLSegmentationNode * lumenSegmentationNode, std::string segmentID,
-                                                                  vtkPolyData * enclosedSurface, bool updateMesh)
+                                                                  vtkPolyData * enclosedSurface)
 {
   Q_D(qSlicerStenosisMeasurement3DModuleWidget);
   if (d->isLumenCacheValid)
@@ -773,7 +764,7 @@ bool qSlicerStenosisMeasurement3DModuleWidget::getEnclosedSurface(vtkMRMLMarkups
   else
   {
     vtkSlicerStenosisMeasurement3DLogic::EnclosingType enclosingType = this->createEnclosedSurface(
-              wallShapeNode, lumenSegmentationNode, segmentID, enclosedSurface, updateMesh);
+              wallShapeNode, lumenSegmentationNode, segmentID, enclosedSurface);
     if (enclosingType == vtkSlicerStenosisMeasurement3DLogic::EnclosingType_Last)
     {
       this->showStatusMessage(qSlicerStenosisMeasurement3DModuleWidget::tr("Error getting the enclosed lumen."), 5000);
@@ -920,7 +911,7 @@ void qSlicerStenosisMeasurement3DModuleWidget::dumpAggregateVolumes()
   vtkMRMLSegmentationNode * segmentationNode = vtkMRMLSegmentationNode::SafeDownCast(d->parameterNode->GetInputSegmentationNode());
   std::string segmentID = d->parameterNode->GetInputSegmentID();
   vtkNew<vtkPolyData> enclosedSurface;
-  if (!this->getEnclosedSurface(wallShapeNode, segmentationNode, segmentID, enclosedSurface, true))
+  if (!this->getEnclosedSurface(wallShapeNode, segmentationNode, segmentID, enclosedSurface))
   {
     return;
   }

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
@@ -74,10 +74,10 @@ protected:
   vtkSlicerStenosisMeasurement3DLogic::EnclosingType
   createEnclosedSurface(vtkMRMLMarkupsShapeNode * wallShapeNode,
                         vtkMRMLSegmentationNode * lumenSegmentationNode, std::string segmentID,
-                        vtkPolyData * enclosedSurface, bool updateMesh = true);
+                        vtkPolyData * enclosedSurface);
   bool getEnclosedSurface(vtkMRMLMarkupsShapeNode * wallShapeNode,
                           vtkMRMLSegmentationNode * lumenSegmentationNode, std::string segmentID,
-                          vtkPolyData * enclosedSurface, bool updateMesh = true); // From cache or create.
+                          vtkPolyData * enclosedSurface); // From cache or create.
 
   void showResult(vtkPolyData * wall, vtkPolyData * lumen, vtkVariantArray * results);
   void createLesionModel(vtkMRMLMarkupsShapeNode * wallShapeNode, vtkPolyData * enclosedSurface,


### PR DESCRIPTION
Drop a re-meshing function.
SlicerStenosisMeasurement3D

This function was meant to improve the wireframe view of the lesion model. It
implied converting a polydata into a segment, from which a closed surface
representation was obtained. The side effect can be a shrinking of the segment.
Drop the function to remove this error margin.
\----------------------------
Clip the enclosed lumen using the segment editor.
CrossSectionAnalysis

Previously, the clipping was done using the closed surface representation of the
segment. The result may shrink when converted back to a label map. The current
method ensures consistency with the source segment.
\----------------------------