### PR TITLE
Multiple fixes

### DIFF
--- a/BranchClipper/CMakeLists.txt
+++ b/BranchClipper/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MODULE_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleLogic
   qSlicer${MODULE_NAME}ModuleWidgets
   ${ITK_LIBRARIES}
+  vtkSlicerSegmentationsModuleLogic
   )
 
 set(MODULE_RESOURCES

--- a/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
+++ b/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
@@ -29,6 +29,7 @@
 #include <vtkMRMLSubjectHierarchyNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLDisplayNode.h>
+#include <vtkSlicerSegmentationsModuleLogic.h>
 #include <vtkPolyDataCollection.h>
 #include <vtkTimerLog.h>
 
@@ -260,23 +261,14 @@ void qSlicerBranchClipperModuleWidget::onApply()
       }
       if (inputSegmentationNode)
       {
-        // Control branch segment name, id and colour.
+        // Control branch segment name.
         std::string branchName = inputSegmentName + std::string("_Branch_") + std::to_string((int) i);
-        // Don't duplicate on repeat apply.
-        /*
-        * Don't use AddSegmentFromClosedSurfaceRepresentation().
-        * Parameter segmentId is marked vtkNotUsed().
-        */
-        vtkSmartPointer<vtkSegment> segment = vtkSmartPointer<vtkSegment>::New();
-        segment->SetName(branchName.c_str());
-        segment->SetTag("Segmentation.Status", "inprogress");
-        if (segment->AddRepresentation(vtkSegmentationConverter::GetClosedSurfaceRepresentationName(), branchSurface))
+        std::string branchId = inputSegmentationNode->AddSegmentFromClosedSurfaceRepresentation(branchSurface, branchName);
+        vtkSegment * segment = inputSegmentationNode->GetSegmentation()->GetSegment(branchId);
+        if (segment)
         {
-          inputSegmentationNode->GetSegmentation()->AddSegment(segment);
-        }
-        else
-        {
-          cerr << "Could not add a closed surface representation to a branch segment." << endl;
+          vtkSlicerSegmentationsModuleLogic::SetSegmentStatus(segment, vtkSlicerSegmentationsModuleLogic::InProgress);
+          // Don't call Modified().
         }
       }
       else if(inputModelNode)

--- a/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
+++ b/BranchClipper/qSlicerBranchClipperModuleWidget.cxx
@@ -147,6 +147,13 @@ void qSlicerBranchClipperModuleWidget::onApply()
       this->showStatusMessage(msg, 5000);
       return;
     }
+    if (inputSegmentationNode->GetSegmentation()->GetNumberOfSegments() == 0)
+    {
+      const QString msg = qSlicerBranchClipperModuleWidget::tr("No segment found in the segmentation, aborting");
+      cerr << msg.toStdString() << endl;
+      this->showStatusMessage(msg, 5000);
+      return;
+    }
     if (inputSegmentationNode && inputSegmentationNode->CreateClosedSurfaceRepresentation())
     {
       // ID of input whole segment.

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -148,7 +148,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.ui.axialSpinSliderWidget.connect("valueChanged(double)", lambda value: self.setValueInParameterNode(ROLE_AXIAL_SPIN_ANGLE, value))
     self.ui.longitudinalSpinSliderWidget.connect("valueChanged(double)", lambda value: self.setValueInParameterNode(ROLE_LONGITUDINAL_SPIN_ANGLE, value))
     self.ui.showMISDiameterButton.connect("toggled(bool)", lambda value: self.setValueInParameterNode(ROLE_SHOW_MIS_MODEL, "True" if value else "False"))
-    self.ui.showCrossSectionButton.connect("toggled(bool)", lambda value: self.setValueInParameterNode(ROLE_SHOW_CROSS_SECTION_MODEL, "True" if value else "False"))
+    self.ui.showLumenCrossSectionButton.connect("toggled(bool)", lambda value: self.setValueInParameterNode(ROLE_SHOW_CROSS_SECTION_MODEL, "True" if value else "False"))
     self.ui.showWallCrossSectionButton.connect("toggled(bool)", lambda value: self.setValueInParameterNode(ROLE_SHOW_WALL_CROSS_SECTION_MODEL, "True" if value else "False"))
     self.ui.axialSliceHorizontalFlipCheckBox.connect("clicked()", lambda: self.setValueInParameterNode(ROLE_AXIAL_HORIZONTAL_FLIP, str(self.ui.axialSliceHorizontalFlipCheckBox.isChecked())))
     self.ui.axialSliceVerticalFlipCheckBox.connect("clicked()", lambda : self.setValueInParameterNode(ROLE_AXIAL_VERTICAL_FLIP, str(self.ui.axialSliceVerticalFlipCheckBox.isChecked())))
@@ -389,7 +389,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.ui.axialSpinSliderWidget.setValue(self.logic.axialSpinAngleDeg)
     self.ui.longitudinalSpinSliderWidget.setValue(self.logic.longitudinalSpinAngleDeg)
     self.ui.showMISDiameterButton.setChecked(self.logic.showMaximumInscribedSphere)
-    self.ui.showCrossSectionButton.setChecked(self.logic.showCrossSection)
+    self.ui.showLumenCrossSectionButton.setChecked(self.logic.showLumenCrossSection)
     self.ui.showWallCrossSectionButton.setChecked(self.logic.showWallCrossSection)
     self.ui.axialSliceHorizontalFlipCheckBox.setChecked(self.logic.axialSliceHorizontalFlip)
     self.ui.axialSliceVerticalFlipCheckBox.setChecked(self.logic.axialSliceVerticalFlip)
@@ -415,7 +415,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
 
     self.ui.moveToMinimumAreaButton.enabled = self.logic.lumenSurfaceNode is not None
     self.ui.moveToMaximumAreaButton.enabled = self.logic.lumenSurfaceNode is not None
-    self.ui.showCrossSectionButton.enabled = self.logic.lumenSurfaceNode is not None
+    self.ui.showLumenCrossSectionButton.enabled = self.logic.lumenSurfaceNode is not None
 
     self.ui.kernelSizeSpinBox.setValue(float(self._parameterNode.GetParameter(ROLE_INPUT_KERNEL_SIZE))
                                        if self._parameterNode.GetParameter(ROLE_INPUT_KERNEL_SIZE) else 1.1)
@@ -475,7 +475,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
 
       self.ui.moveToMinimumAreaButton.enabled = self.logic.lumenSurfaceNode is not None
       self.ui.moveToMaximumAreaButton.enabled = self.logic.lumenSurfaceNode is not None
-      self.ui.showCrossSectionButton.enabled = self.logic.lumenSurfaceNode is not None
+      self.ui.showLumenCrossSectionButton.enabled = self.logic.lumenSurfaceNode is not None
 
       if tableHasData:
         numberOfPoints = self.logic.getNumberOfPoints()
@@ -698,7 +698,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
       self.deleteMaximumInscribedSphere()
 
     # Update the lumen cross-section model
-    if self.ui.showCrossSectionButton.checked and self.logic.lumenSurfaceNode:
+    if self.ui.showLumenCrossSectionButton.checked and self.logic.lumenSurfaceNode:
       crossSectionPolyData = self.logic.updateLumenCrossSection(pointIndex)
       if self.lumenCrossSectionModelNode is None:
         self.lumenCrossSectionModelNode = slicer.modules.models.logic().AddModel(crossSectionPolyData)
@@ -1064,9 +1064,9 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     self.onGetRegionsButton()
 
   def setShowLumenCrossSection(self, checked):
-    self.logic.showCrossSection = checked
+    self.logic.showLumenCrossSection = checked
     if self.lumenCrossSectionModelNode and self.lumenCrossSectionModelNode.GetDisplayNode():
-      self.lumenCrossSectionModelNode.GetDisplayNode().SetVisibility(self.logic.showCrossSection)
+      self.lumenCrossSectionModelNode.GetDisplayNode().SetVisibility(self.logic.showLumenCrossSection)
     if not checked:
       self.deleteLumenCrossSection()
 
@@ -1172,7 +1172,7 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     self.wallSubtractLumenCrossSection = False
     self.decimatedWallPolyDataCache = None
     self.decimateTube = False
-    self.showCrossSection = False
+    self.showLumenCrossSection = False
     self.showWallCrossSection = False
     self.showMaximumInscribedSphere = False
     self.relativeOriginPointIndex = 0

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -1609,22 +1609,6 @@ Caution: values at bifurcations may not have clinical meaning.</string>
    </hints>
   </connection>
   <connection>
-   <sender>segmentationSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>segmentSelector</receiver>
-   <slot>setCurrentNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>405</x>
-     <y>88</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>348</x>
-     <y>108</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>CrossSectionAnalysis</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>longitudinalSliceViewSelector</receiver>

--- a/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
+++ b/CrossSectionAnalysis/Resources/UI/CrossSectionAnalysis.ui
@@ -1199,7 +1199,7 @@ Concerns orthogonal reformat in axial navigation.</string>
            </widget>
           </item>
           <item>
-           <widget class="QToolButton" name="showCrossSectionButton">
+           <widget class="QToolButton" name="showLumenCrossSectionButton">
             <property name="enabled">
              <bool>false</bool>
             </property>

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
@@ -151,9 +151,9 @@ void qSlicerStenosisMeasurement3DModuleWidget::setup()
   this->tubeModifiedObservation->SetClientData( reinterpret_cast<void *>(this) );
   this->tubeModifiedObservation->SetCallback(qSlicerStenosisMeasurement3DModuleWidget::onTubeModified);
 
-  this->segmentationRepresentationObservation = vtkSmartPointer<vtkCallbackCommand>::New();
-  this->segmentationRepresentationObservation->SetClientData( reinterpret_cast<void *>(this) );
-  this->segmentationRepresentationObservation->SetCallback(qSlicerStenosisMeasurement3DModuleWidget::onSegmentationRepresentationModified);
+  this->segmentationSourceRepresentationObservation = vtkSmartPointer<vtkCallbackCommand>::New();
+  this->segmentationSourceRepresentationObservation->SetClientData( reinterpret_cast<void *>(this) );
+  this->segmentationSourceRepresentationObservation->SetCallback(qSlicerStenosisMeasurement3DModuleWidget::onSegmentationSourceRepresentationModified);
 
   this->addMenu();
 
@@ -452,13 +452,18 @@ void qSlicerStenosisMeasurement3DModuleWidget::onSegmentationNodeChanged(vtkMRML
   d->inputSegmentSelector->setCurrentSegmentID("");
   if (d->parameterNode)
   {
+    vtkMRMLSegmentationNode * currentSegmentationNode = d->parameterNode->GetInputSegmentationNode();
+    if (currentSegmentationNode)
+    {
+      currentSegmentationNode->RemoveObserver(this->segmentationSourceRepresentationObservation);
+    }
     d->parameterNode->SetInputSegmentationNodeID(node ? node->GetID() : nullptr);
   }
   this->clearLumenCache();
   this->updateRegionInfo();
   if (node)
   {
-    node->AddObserver(vtkSegmentation::RepresentationModified, this->segmentationRepresentationObservation);
+    node->AddObserver(vtkSegmentation::SourceRepresentationModified, this->segmentationSourceRepresentationObservation);
   }
 }
 
@@ -566,7 +571,7 @@ void qSlicerStenosisMeasurement3DModuleWidget::onTubeModified(vtkObject *caller,
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerStenosisMeasurement3DModuleWidget::onSegmentationRepresentationModified(vtkObject *caller,
+void qSlicerStenosisMeasurement3DModuleWidget::onSegmentationSourceRepresentationModified(vtkObject *caller,
                                                                 unsigned long event, void *clientData, void *callData)
 {
   qSlicerStenosisMeasurement3DModuleWidget * client = reinterpret_cast<qSlicerStenosisMeasurement3DModuleWidget*>(clientData);

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.cxx
@@ -858,8 +858,12 @@ void qSlicerStenosisMeasurement3DModuleWidget::updateGuiFromParameterNode()
   }
 
   d->inputShapeSelector->setCurrentNode(d->parameterNode->GetInputShapeNode());
-  QSignalBlocker blocker(d->inputSegmentSelector);
-  d->inputSegmentSelector->setCurrentNode(d->parameterNode->GetInputSegmentationNode());
+  {
+    QSignalBlocker blocker(d->inputSegmentSelector);
+    d->inputSegmentSelector->setCurrentNode(d->parameterNode->GetInputSegmentationNode());
+    // Force observation of the segmentation.
+    this->onSegmentationNodeChanged(d->parameterNode->GetInputSegmentationNode());
+  }
   d->inputSegmentSelector->setCurrentSegmentID(d->parameterNode->GetInputSegmentID());
   d->inputFiducialSelector->setCurrentNode(d->parameterNode->GetInputFiducialNode());
   d->lesionModelSelector->setCurrentNode(d->parameterNode->GetOutputLesionModelNode());

--- a/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
+++ b/StenosisMeasurement3D/qSlicerStenosisMeasurement3DModuleWidget.h
@@ -97,8 +97,8 @@ protected:
   static void onTubeModified(vtkObject *caller,
                                         unsigned long event, void *clientData, void *callData);
 
-  vtkSmartPointer<vtkCallbackCommand> segmentationRepresentationObservation;
-  static void onSegmentationRepresentationModified(vtkObject *caller,
+  vtkSmartPointer<vtkCallbackCommand> segmentationSourceRepresentationObservation;
+  static void onSegmentationSourceRepresentationModified(vtkObject *caller,
                                         unsigned long event, void *clientData, void *callData);
 
   void setDefaultParameters(vtkMRMLNode * node);


### PR DESCRIPTION
Verify that a segmentation contains segments.
BranchClipper

Prevent a crash that would happen on apply when
 - a successful run on a segmentation has completedi,
 - the next run operates on a segmentation that has no segments.
 
\----------------------------
Show a wall cross-section in full or subtract the lumen.
CrossSectionAnalysis

If a tube is used to represent the arterial wall, its cross-section can be shown
as a model while browsing along the centerline (tube spline).

Previously, the lumen was forcibly subtracted from the wall cross-section. The
lumen cross-section can be shown independently.

A full wall cross-section model is now shown by default to be consistent with
the displayed surface area. The lumen-cross-section can be optionally
subtracted from the wall cross-section via a checkable menu item.
\----------------------------
Rework the selection of an input segmentation, segment or model node.
CrossSectionAnalysis

- disconnect segmentationSelector and segmentSelector in designer +++,
- manage segmentSelector following a change in segmentationSelector,
- simplify the function setting the current segmentation/model node and the
  current segment in logic,
- remove a small hack that synchronised the logic and the parameter node
  regarding the current segmentation/model node and the current segment.

NOTE: Once set in segmentSelector, the currentSegmentID property does not change
if the widget is assigned a None segmentation, or if this property is explicitly
assigned an empty string. It will therefore persist in logic.
\----------------------------
Rename a variable and a widget to include their scope.
CrossSectionAnalysis

Precise that they are related to the lumen to better distinguish with similar
variables handling the wall.
\----------------------------
Simplify the creation of branch segments.
BranchClipper

Use AddSegmentFromClosedSurfaceRepresentation() and set the status to
'inprogress'.
\----------------------------
Observe the source representation of the segmentation.
StenosisMeasurement3D

Observe SourceRepresentationModified event rather than RepresentationModified.

Following:
https://discourse.slicer.org/t/detecting-which-segments-have-been-modified/44453/7
\----------------------------
Force observation of the segmentation node.
StenosisMeasurement3D

This is because of the use of QSignalBlocker on the segmentation selector in
updateGuiFromParameterNode(). QSignalBlocker is used because the interaction
with the segment combobox is a tricky thing.
\----------------------------
