### PR TITLE
Do not alter the representation name of the lumen clipped in the tube.

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -849,9 +849,6 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         """
         inputSegmentation = self.logic.lumenSurfaceNode
         clippedLumenId = inputSegmentation.AddSegmentFromClosedSurfaceRepresentation(tubeSurface, clippedLumenName)
-        representationName = inputSegmentation.GetDisplayNode().GetPreferredDisplayRepresentationName3D()
-        inputSegmentation.GetSegmentation().RemoveRepresentation(representationName)
-        inputSegmentation.GetSegmentation().CreateRepresentation(representationName)
 
         segmentEditorModuleWidget = slicer.util.getModuleWidget("SegmentEditor")
         seWidget = segmentEditorModuleWidget.editor


### PR DESCRIPTION
CrossSectionAnalysis

The removed lines are a remnant of a previous processing that operated on the closed surface representation of the input lumen and the tube. Since the clipping is now performed by direct intersection of binary label maps, there is no need to change their representations.

See:
  https://discourse.slicer.org/t/visible-segment-in-3d-may-have-a-none-representation-name/44475