### PR TITLE
Add missing include - vtkMRMLI18N.h.

### DIFF
--- a/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
+++ b/StenosisMeasurement3D/Logic/vtkSlicerStenosisMeasurement3DLogic.cxx
@@ -53,6 +53,7 @@
 #include <vtkTableToSQLiteWriter.h>
 #include <vtkSQLiteQuery.h>
 #include <vtkQuadricDecimation.h>
+#include <vtkMRMLI18N.h>
 
 static const char* COLUMN_NAME_STUDY = "Study";
 static const char* COLUMN_NAME_WALL = "WallVolume";


### PR DESCRIPTION
StenosisMeasurement3D

This file (in MRML core) is not found for stable (VTK 9.2) on cdash, but it is found for preview (VTK 9.5).