### PR TITLE
Improve the cross-section handling of the wall and the lumen.

### DIFF
--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -864,7 +864,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         # Tag the clipped segment.
         segment = inputSegmentation.GetSegmentation().GetSegment(clippedLumenId)
         # reference = vtk.reference(1)
-        segment.SetTag(SEGMENT_TAG_NAME_CLIPPED, 1) # Not used.
+        segment.SetTag(TAG_NAME_CLIPPED, 1) # Not used.
         """
         vtkMRMLSegmentationDisplayNode::SegmentDisplayProperties does not seem accessible in python.
         Can't clone the display properties of the source segment into the new segment.
@@ -886,6 +886,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         normals.Update()
         clippedModel = slicer.modules.models.logic().AddModel(normals.GetOutput())
         clippedModel.SetName(clippedLumenName)
+        clippedModel.SetAttribute(self.moduleName + "." + TAG_NAME_CLIPPED, "1")
         self.ui.segmentationSelector.setCurrentNode(clippedModel)
 
   def updateWallLabelsVisibility(self):
@@ -2133,7 +2134,7 @@ WALL_CROSS_SECTION_AREA_ARRAY_NAME = _("Wall cross-section area")
 SURFACE_AREA_STENOSIS_ARRAY_NAME = _("Stenosis by surface area")
 DIAMETER_STENOSIS_ARRAY_NAME = _("Stenosis by diameter (CE)")
 
-SEGMENT_TAG_NAME_CLIPPED = "ClippedInTube"
+TAG_NAME_CLIPPED = "ClippedInTube"
 
 MIS_DIAMETER = "MIS_DIAMETER"
 CE_DIAMETER = "CE_DIAMETER"

--- a/CrossSectionAnalysis/CrossSectionAnalysis.py
+++ b/CrossSectionAnalysis/CrossSectionAnalysis.py
@@ -209,7 +209,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
       self._wallCrossSectionTypeMenu.addAction(self._wallCrossSectionTypeAction)
       # Update the parameter node.
       self._wallCrossSectionTypeAction.connect("toggled(bool)", lambda value: self.setValueInParameterNode(ROLE_WALL_SUBTRACT_LUMEN_CROSSSECTION, value))
-      # And perform a selective cache reset.
+      # And reset the cross-section caches.
       self._wallCrossSectionTypeAction.connect("toggled(bool)", lambda value: self.updateWallCrossSectionType(value, int(self.ui.moveToPointSliderWidget.value)))
     if (self.logic.inputCenterlineNode and self.logic.inputCenterlineNode.IsTypeOf("vtkMRMLMarkupsShapeNode")
         and self.logic.lumenSurfaceNode):
@@ -1088,10 +1088,7 @@ class CrossSectionAnalysisWidget(ScriptedLoadableModuleWidget, VTKObservationMix
   # Create a wall cross-section with or without the lumen cross-section.
   def updateWallCrossSectionType(self, value, pointIndex):
     self.logic.wallSubtractLumenCrossSection = value
-    if not self.logic.wallCrossSectionPolyDataCache:
-      return
-    # Replace a cached cross-section at this index selectively.
-    self.logic.wallCrossSectionPolyDataCache.pop(pointIndex)
+    self.logic.resetPolyDataCaches(False) # Don't reset the decimated wall cache.'
     self.setCurrentPointIndex(pointIndex)
 
   def setShowMaximumInscribedSphereDiameter(self, checked):
@@ -1208,10 +1205,11 @@ class CrossSectionAnalysisLogic(ScriptedLoadableModuleLogic):
     parameterNode.SetParameter(ROLE_INPUT_KERNEL_SIZE, str(1.1))
     parameterNode.SetParameter(ROLE_INITIALIZED, "1")
 
-  def resetPolyDataCaches(self):
+  def resetPolyDataCaches(self, all = True):
     self.lumenCrossSectionPolyDataCache = {}
     self.wallCrossSectionPolyDataCache = {}
-    self.decimatedWallPolyDataCache = None
+    if (all):
+      self.decimatedWallPolyDataCache = None
 
   def setInputCenterlineNode(self, centerlineNode):
     if self.inputCenterlineNode == centerlineNode:

--- a/CrossSectionAnalysis/Logic/vtkCrossSectionCompute.h
+++ b/CrossSectionAnalysis/Logic/vtkCrossSectionCompute.h
@@ -47,15 +47,16 @@ public:
    * The cross-section area and circular equivalent diameter
    * columns of the output table are updated in parallel.
    */
+  enum ExtractionMode{LargestRegion = 0, AllRegions, ClosestPoint};
   bool UpdateTable(vtkDoubleArray * crossSectionAreaArray, vtkDoubleArray * ceDiameterArray,
-                   vtkIdList* emptySectionIds  = nullptr);
+                   vtkIdList* emptySectionIds  = nullptr,
+                   ExtractionMode extractionMode = ExtractionMode::ClosestPoint);
 
   /**
    * Create a cross-section polydata of the input polydata with a given plane.
    * In ClosestPoint mode, holes nearby to the reference point are rightly
    * excluded.
    */
-  enum ExtractionMode{LargestRegion = 0, AllRegions, ClosestPoint};
   enum SectionCreationResult {Success = 0, Abort, Empty};
   static SectionCreationResult CreateCrossSection(vtkPolyData * result, vtkPolyData * input,
                                           vtkPlane * plane,


### PR DESCRIPTION
Improve the cross-section handling of the wall and the lumen.

0263032	Set an attribute to a model clipped inside a tube.
CrossSectionAnalysis

Using CrossSectionAnalysis.ClippedInTube set to 1.
\----------------------------

1ed60be	Specify the extraction mode when updating the output table.
CrossSectionAnalysis

This value was forcibly ClosestPoint, referring to the closest cut region to the
centerline. Some other extraction mode is allowed in anticipation of a next
patch that will consider whether a lumen is clipped in a tube or not.
\----------------------------

10dd7ea	Use an adequate lumen extraction mode when creating a cross-section.
CrossSectionAnalysis

If a Tube is used together with a clipped lumen (segment or model), create the
cross-section of the lumen using the AllRegions option. In all other cases, use
the default ClosestPoint option (closest to the spline of the Tube).

This may avoid the case of the cross-section of a small hump in a very irregular
stenosis being selected, ignoring the nearby circulating lumen.
\----------------------------

9603598	Always clear the cross-section polydata caches.
CrossSectionAnalysis

Previously, when the wall cross-section type was changed (subtract the lumen or
not), only the cross-section at this point index of the spline was updated.

By clearing the caches completely, the displayed cross-section of the wall at
any point becomes predictable when the display type is toggled many times while
browsing along the spline.
\----------------------------

<img width="1391" height="1025" alt="CrossSectionAnalysis_Tube_Clipped_Lumen_0" src="https://github.com/user-attachments/assets/17f9fd81-8873-4905-afbc-8cddd891263d" />

